### PR TITLE
Packaging test scripts + cpack fixes [skip ci]

### DIFF
--- a/.github/workflows/cpack-opensuse.yml
+++ b/.github/workflows/cpack-opensuse.yml
@@ -35,7 +35,7 @@ jobs:
           popd
 
       - name: Build Release
-        timeout-minutes: 120
+        timeout-minutes: 150
         run: |
           pushd docker
           ./build-docker-release.sh --distro opensuse --versions ${{ matrix.os }} --rocm-versions ${{ matrix.rocm-version }} -- ${{ matrix.extensions }}
@@ -69,27 +69,17 @@ jobs:
         run: |
           mv build-release/stgz/*.sh ./
           mv build-release/deb/*.rpm ./
-          rm -rf build-release
-          rm -rf /opt/omnitrace
+          sudo rm -rf build-release
+          sudo rm -rf /opt/omnitrace
 
       - name: Test STGZ Install
         timeout-minutes: 20
         continue-on-error: true
         run: |
           set -v
-          mkdir /opt/omnitrace-stgz
-          export PATH=/opt/omnitrace-stgz/bin:${PATH}
-          export LD_LIBRARY_PATH=/opt/omnitrace-stgz/lib:${LD_LIBRARY_PATH}
           for i in omnitrace-*.sh
           do
-            echo -e "\n###### Testing ${i}... #####\n"
-            ./${i} --prefix=/opt/omnitrace-stgz --skip-license --exclude-dir
-            omnitrace-avail --help
-            omnitrace --help
-            omnitrace-python --help
-            set +e
-            rm -rf /opt/omnitrace-stgz/*
-            set -e
+            ./docker/test-docker-release.sh --distro opensuse --versions ${{ matrix.os }} --rocm-versions ${{ matrix.rocm-version }} -- --stgz ${i}
           done
 
       - name: Test RPM Install
@@ -97,20 +87,7 @@ jobs:
         continue-on-error: true
         run: |
           set -v
-          export PATH=/opt/omnitrace/bin:${PATH}
-          export LD_LIBRARY_PATH=/opt/omnitrace/lib:${LD_LIBRARY_PATH}
-          sudo apt-get install -y alien fakeroot
           for i in omnitrace-*.rpm
           do
-            echo -e "\n###### Testing ${i}... #####\n"
-            i=$(fakeroot alien ./${i} | awk '{print $1}')
-            dpkg --contents ./${i}
-            sudo dpkg -i ./${i}
-            omnitrace-avail --help
-            omnitrace --help
-            omnitrace-python --help
-            sudo apt-get remove -y omnitrace
-            set +e
-            rm -rf /opt/omnitrace/*
-            set -e
+            ./docker/test-docker-release.sh --distro opensuse --versions ${{ matrix.os }} --rocm-versions ${{ matrix.rocm-version }} -- --rpm ${i}
           done

--- a/.github/workflows/cpack-ubuntu.yml
+++ b/.github/workflows/cpack-ubuntu.yml
@@ -32,7 +32,7 @@ jobs:
           popd
 
       - name: Build Release
-        timeout-minutes: 120
+        timeout-minutes: 150
         run: |
           pushd docker
           ./build-docker-release.sh --distro ubuntu --versions ${{ matrix.os }} --rocm-versions ${{ matrix.rocm-version }} -- ${{ matrix.extensions }}
@@ -66,27 +66,17 @@ jobs:
         run: |
           mv build-release/stgz/*.sh ./
           mv build-release/deb/*.deb ./
-          rm -rf build-release
-          rm -rf /opt/omnitrace
+          sudo rm -rf build-release
+          sudo rm -rf /opt/omnitrace
 
       - name: Test STGZ Install
         timeout-minutes: 20
         continue-on-error: true
         run: |
           set -v
-          mkdir /opt/omnitrace-stgz
-          export PATH=/opt/omnitrace-stgz/bin:${PATH}
-          export LD_LIBRARY_PATH=/opt/omnitrace-stgz/lib:${LD_LIBRARY_PATH}
           for i in omnitrace-*.sh
           do
-            echo -e "\n###### Testing ${i}... #####\n"
-            ./${i} --prefix=/opt/omnitrace-stgz --skip-license --exclude-dir
-            omnitrace-avail --help
-            omnitrace --help
-            omnitrace-python --help
-            set +e
-            rm -rf /opt/omnitrace-stgz/*
-            set -e
+            ./docker/test-docker-release.sh --distro ubuntu --versions ${{ matrix.os }} --rocm-versions ${{ matrix.rocm-version }} -- --stgz ${i}
           done
 
       - name: Test DEB Install
@@ -94,18 +84,7 @@ jobs:
         continue-on-error: true
         run: |
           set -v
-          export PATH=/opt/omnitrace/bin:${PATH}
-          export LD_LIBRARY_PATH=/opt/omnitrace/lib:${LD_LIBRARY_PATH}
           for i in omnitrace_*.deb
           do
-            echo -e "\n###### Testing ${i}... #####\n"
-            dpkg --contents ./${i}
-            sudo dpkg -i ./${i}
-            omnitrace-avail --help
-            omnitrace --help
-            omnitrace-python --help
-            sudo apt-get remove -y omnitrace
-            set +e
-            rm -rf /opt/omnitrace/*
-            set -e
+            ./docker/test-docker-release.sh --distro ubuntu --versions ${{ matrix.os }} --rocm-versions ${{ matrix.rocm-version }} -- --deb ${i}
           done

--- a/docker/test-docker-release.sh
+++ b/docker/test-docker-release.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+if [ ! -f CMakeLists.txt ]; then
+    if [ ! -f ../CMakeLists.txt ]; then
+        echo "Error! Execute script from source directory"
+        exit 1
+    else
+        cd ..
+    fi
+fi
+
+set -e
+
+send-error()
+{
+    echo -e "\nError: ${@}"
+    exit 1
+}
+
+verbose-run()
+{
+    echo -e "\n\n### Executing \"${@}\"... ###\n"
+    eval $@
+}
+
+test-release()
+{
+    CONTAINER=${1}
+    shift
+    verbose-run docker run --rm -v ${PWD}:/home/omnitrace ${CONTAINER} /home/omnitrace/scripts/test-release.sh ${@}
+}
+
+: ${DISTRO:=ubuntu}
+: ${VERSIONS:=20.04 18.04}
+: ${ROCM_VERSIONS:=5.0 4.5 4.3}
+
+n=0
+while [[ $# -gt 0 ]]
+do
+    case "${1}" in
+        "--distro")
+            shift
+            DISTRO=${1}
+            ;;
+        "--versions")
+            shift
+            VERSIONS=${1}
+            ;;
+        "--rocm-versions")
+            shift
+            ROCM_VERSIONS=${1}
+            ;;
+        "--")
+            shift
+            SCRIPT_ARGS=${@}
+            break
+            ;;
+        *)
+            send-error "Unsupported argument at position $((${n} + 1)) :: ${1}"
+            ;;
+    esac
+    n=$((${n} + 1))
+    shift
+done
+
+CODE_VERSION=$(cat VERSION)
+
+for VERSION in ${VERSIONS}
+do
+    TAG=${DISTRO}-${VERSION}
+    for ROCM_VERSION in ${ROCM_VERSIONS}
+    do
+        test-release jrmadsen/omnitrace-${TAG}-rocm-${ROCM_VERSION} ${SCRIPT_ARGS}
+    done
+done

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -1,0 +1,170 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=$(realpath $(dirname ${BASH_SOURCE[0]}))
+cd $(dirname ${SCRIPT_DIR})
+echo -e "Working directory: $(pwd)"
+
+umask 0000
+
+verbose-run()
+{
+    echo -e "\n##### Executing \"${@}\"... #####\n"
+    eval $@
+}
+
+: ${RPM_FILE:=""}
+: ${DEB_FILE:=""}
+: ${STGZ_FILE:=""}
+: ${SUDO_CMD:=""}
+
+usage()
+{
+    print_option() { printf "    --%-10s %-24s     %s\n" "${1}" "${2}" "${3}"; }
+    echo "Options:"
+    print_option stgz "<FILE>" "Run installation test on STGZ package"
+    print_option deb "<FILE>" "Run installation test on DEB package"
+    print_option rpm "<FILE>" "Run installation test on RPM package"
+    print_option sudo "" "Execute commands with sudo"
+}
+
+while [[ $# -gt 0 ]]
+do
+    ARG=${1}
+    shift
+
+    case "${ARG}" in
+        --clean)
+            CLEAN=1
+            continue
+            ;;
+        --fresh)
+            FRESH=1
+            continue
+            ;;
+    esac
+
+    VAL=""
+    while [[ $# -gt 0 ]]
+    do
+        VAL=${1}
+        shift
+        break
+    done
+
+    if [ -z "${VAL}" ]; then
+        echo "Error! Missing value for argument \"${ARG}\""
+        usage
+        exit -1
+    fi
+
+    case "${ARG}" in
+        ? | -h | --help)
+            usage
+            exit 0
+            ;;
+        --stgz)
+            STGZ_FILE=${VAL}
+            ;;
+        --deb)
+            DEB_FILE=${VAL}
+            ;;
+        --rpm)
+            RPM_FILE=${VAL}
+            ;;
+        --sudo)
+            SUDO_CMD=sudo
+            ;;
+        *)
+            echo -e "Error! Unknown option : ${ARG}"
+            usage
+            exit -1
+            ;;
+    esac
+done
+
+remove-pycache()
+{
+    rm -rf ${1}/lib/python/site-packages/omnitrace/__pycache__
+}
+
+setup-env()
+{
+    rm -rf ${1}/*
+    export PATH=${1}/bin:${PATH}
+    export LD_LIBRARY_PATH=${1}/lib:/opt/rocm/lib:${LD_LIBRARY_PATH}
+}
+
+test-install()
+{
+    verbose-run omnitrace --help
+    verbose-run omnitrace-avail --help
+    verbose-run omnitrace-avail --all
+    if [ -d "${1}/lib/python/site-packages/omnitrace" ]; then
+        verbose-run omnitrace-python --help
+    fi
+}
+
+change-directory()
+{
+    if [ ! -f "${1}" ]; then
+        if [ -f "/home/omnitrace/${1}" ]; then
+            cd /home/omnitrace
+        elif [ -f "/home/omnitrace/docker/${1}" ]; then
+            cd /home/omnitrace/docker
+        fi
+    fi
+    realpath ${1}
+}
+
+test-stgz()
+{
+    if [ -z "${1}" ]; then return; fi
+
+    local INSTALLER=$(change-directory ${1})
+    mkdir /opt/omnitrace-stgz
+    setup-env /opt/omnitrace-stgz
+
+    verbose-run ${INSTALLER} --prefix=/opt/omnitrace-stgz --skip-license --exclude-dir
+
+    test-install /opt/omnitrace-stgz
+}
+
+test-deb()
+{
+    if [ -z "${1}" ]; then return; fi
+
+    local INSTALLER=$(change-directory ${1})
+    setup-env /opt/omnitrace
+
+    verbose-run ${SUDO_CMD} dpkg --contents ${INSTALLER}
+    verbose-run ${SUDO_CMD} dpkg -i ${INSTALLER}
+
+    test-install /opt/omnitrace
+    remove-pycache /opt/omnitrace
+    verbose-run apt-get remove -y omnitrace
+    if [ -d /opt/omnitrace ]; then
+        find /opt/omnitrace -type f
+    fi
+}
+
+test-rpm()
+{
+    if [ -z "${1}" ]; then return; fi
+
+    local INSTALLER=$(change-directory ${1})
+    setup-env /opt/omnitrace
+
+    verbose-run ${SUDO_CMD} rpm -ql -p ${INSTALLER}
+    verbose-run ${SUDO_CMD} rpm -v -i -p ${INSTALLER} --nodeps
+
+    test-install /opt/omnitrace
+    remove-pycache /opt/omnitrace
+    verbose-run rpm -e omnitrace
+    if [ -d /opt/omnitrace ]; then
+        find /opt/omnitrace -type f
+    fi
+}
+
+test-stgz ${STGZ_FILE}
+test-deb  ${DEB_FILE}
+test-rpm  ${RPM_FILE}


### PR DESCRIPTION
- `scripts/test-release.sh` provides a script to test the installation of a release
  - this is useful when the installation is in a docker container
- `scripts/test-docker-release.sh` executes `test-release.sh` in a container
- miscellaneous fixes to cpack workflows