### PR TITLE
Minor updates for transpose, timemory submodule, roctracer, and omnitrace exe

### DIFF
--- a/examples/transpose/transpose.cpp
+++ b/examples/transpose/transpose.cpp
@@ -187,6 +187,18 @@ main(int argc, char** argv)
     int    nthreads = 2;
     int    nitr     = 5000;
     size_t nsync    = 10;
+    for(int i = 1; i < argc; ++i)
+    {
+        auto _arg = std::string{ argv[i] };
+        if(_arg == "?" || _arg == "-h" || _arg == "--help")
+        {
+            fprintf(stderr,
+                    "usage: transpose [NUM_THREADS (%i)] [NUM_ITERATION (%i)] "
+                    "[SYNC_EVERY_N_ITERATIONS (%zu)]\n",
+                    nthreads, nitr, nsync);
+            exit(EXIT_SUCCESS);
+        }
+    }
     if(argc > 1) nthreads = atoi(argv[1]);
     if(argc > 2) nitr = atoi(argv[2]);
     if(argc > 3) nsync = atoll(argv[3]);

--- a/source/bin/omnitrace/CMakeLists.txt
+++ b/source/bin/omnitrace/CMakeLists.txt
@@ -22,9 +22,9 @@ target_link_libraries(
     omnitrace-exe
     PRIVATE omnitrace::omnitrace-headers
             omnitrace::omnitrace-dyninst
-            omnitrace::omnitrace-timemory
             omnitrace::omnitrace-compile-options
             omnitrace::omnitrace-compile-definitions
+            timemory::timemory-headers
             $<IF:$<BOOL:${OMNITRACE_USE_SANITIZER}>,omnitrace::omnitrace-sanitizer,>)
 
 set_target_properties(

--- a/source/bin/omnitrace/omnitrace.cpp
+++ b/source/bin/omnitrace/omnitrace.cpp
@@ -24,6 +24,8 @@
 #include "fwd.hpp"
 
 #include <timemory/config.hpp>
+#include <timemory/hash.hpp>
+#include <timemory/manager.hpp>
 #include <timemory/settings.hpp>
 
 #include <algorithm>

--- a/source/lib/omnitrace/library/components/roctracer.hpp
+++ b/source/lib/omnitrace/library/components/roctracer.hpp
@@ -33,6 +33,7 @@
 #include <timemory/macros/os.hpp>
 #include <timemory/mpl/type_traits.hpp>
 #include <timemory/mpl/types.hpp>
+#include <timemory/utility/transient_function.hpp>
 
 namespace tim
 {
@@ -64,6 +65,10 @@ struct roctracer
 
     void start();
     void stop();
+
+    // this function protects roctracer_flush_activty from being called
+    // when omnitrace exits during a callback
+    [[nodiscard]] static scope::transient_destructor protect_flush_activity();
 };
 
 #if !defined(OMNITRACE_USE_ROCTRACER)


### PR DESCRIPTION
- usage message in transpose example
- updates timemory submodule
- roctracer updates
  - Changes to verbosity of roctracer::shutdown
  - protect_flush_activity prevents deadlock when error in callback
- omnitrace exe does not link to `timemory-cxx` target