### PR TITLE
omnitrace function exclude updates

### DIFF
--- a/source/bin/omnitrace/details.cpp
+++ b/source/bin/omnitrace/details.cpp
@@ -48,7 +48,8 @@ get_whole_function_names()
         "rocr::core::Signal::WaitAny", "rocr::core::Runtime::AsyncEventsLoop",
         "rocr::core::BusyWaitSignal::WaitAcquire",
         "rocr::core::BusyWaitSignal::WaitRelaxed", "rocr::HSA::hsa_signal_wait_scacquire",
-        "rocr::os::ThreadTrampoline", "event_base_loop"
+        "rocr::os::ThreadTrampoline", "rocr::image::ImageRuntime::CreateImageManager",
+        "rocr::AMD::GpuAgent::GetInfo", "rocr::HSA::hsa_agent_get_info", "event_base_loop"
     };
 #else
     // should hopefully be removed soon

--- a/source/bin/omnitrace/module_function.cpp
+++ b/source/bin/omnitrace/module_function.cpp
@@ -415,9 +415,10 @@ module_function::is_routine_constrained() const
         "S)_|::basic_string[a-zA-Z,<>: ]+::_M_create|::__|::_(Alloc|State)|"
         "std::(basic_|)(ifstream|ios|istream|ostream|stream))",
         regex_opts);
-    static std::regex leading("^(_|\\.|frame_dummy|transaction clone|virtual "
-                              "thunk|non-virtual thunk|\\(|targ|kmp_threadprivate_)",
-                              regex_opts);
+    static std::regex leading(
+        "^(_|\\.|frame_dummy|transaction clone|virtual "
+        "thunk|non-virtual thunk|\\(|targ|kmp_threadprivate_|Kokkos::Profiling::)",
+        regex_opts);
     static std::regex trailing(
         "(_|\\.part\\.[0-9]+|\\.constprop\\.[0-9]+|\\.|\\.[0-9]+)$", regex_opts);
     static strset_t whole = []() {


### PR DESCRIPTION
- These functions cause weird call-stack behavior when instrumented
    - rocr::image::ImageRuntime::CreateImageManager
    - rocr::AMD::GpuAgent::GetInfo
    - rocr::HSA::hsa_agent_get_info
- These functions cause out-of-order call-stacks when KokkosP is enabled
    - Kokkos::Profiling::*