### PR TITLE
Critical trace updates

### DIFF
--- a/source/lib/omnitrace/library.cpp
+++ b/source/lib/omnitrace/library.cpp
@@ -220,11 +220,11 @@ omnitrace_push_trace_hidden(const char* name)
     {
         uint64_t _cid                       = 0;
         uint64_t _parent_cid                = 0;
-        uint16_t _depth                     = 0;
+        uint32_t _depth                     = 0;
         std::tie(_cid, _parent_cid, _depth) = create_cpu_cid_entry();
         auto _ts                            = comp::wall_clock::record();
         add_critical_trace<Device::CPU, Phase::BEGIN>(
-            threading::get_id(), _cid, 0, _parent_cid, _ts, 0, 0,
+            threading::get_id(), _cid, 0, _parent_cid, _ts, 0, 0, 0,
             critical_trace::add_hash_id(name), _depth);
     }
 }
@@ -262,11 +262,11 @@ omnitrace_pop_trace_hidden(const char* name)
                 if(get_cpu_cid_parents()->find(_cid) != get_cpu_cid_parents()->end())
                 {
                     uint64_t _parent_cid          = 0;
-                    uint16_t _depth               = 0;
+                    uint32_t _depth               = 0;
                     auto     _ts                  = comp::wall_clock::record();
                     std::tie(_parent_cid, _depth) = get_cpu_cid_parents()->at(_cid);
                     add_critical_trace<Device::CPU, Phase::END>(
-                        threading::get_id(), _cid, 0, _parent_cid, _ts, _ts, 0,
+                        threading::get_id(), _cid, 0, _parent_cid, _ts, _ts, 0, 0,
                         critical_trace::add_hash_id(name), _depth);
                 }
             }
@@ -476,7 +476,7 @@ omnitrace_init_library_hidden()
     // below will effectively do:
     //      get_cpu_cid_stack(0)->emplace_back(-1);
     // plus query some env variables
-    add_critical_trace<Device::CPU, Phase::NONE>(0, -1, 0, 0, 0, 0, 0, 0, 0);
+    add_critical_trace<Device::CPU, Phase::NONE>(0, -1, 0, 0, 0, 0, 0, 0, 0, -1, 0);
 
     if(gpu::device_count() == 0 && get_state() != State::Active)
     {

--- a/source/lib/omnitrace/library/components/pthread_mutex_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_mutex_gotcha.cpp
@@ -139,7 +139,7 @@ pthread_mutex_gotcha::operator()(const gotcha_data_t& _data,
 
     uint64_t _cid        = 0;
     uint64_t _parent_cid = 0;
-    uint16_t _depth      = 0;
+    uint32_t _depth      = 0;
     int64_t  _ts         = 0;
 
     OMNITRACE_SCOPED_THREAD_STATE(ThreadState::Internal);
@@ -157,7 +157,7 @@ pthread_mutex_gotcha::operator()(const gotcha_data_t& _data,
     if(get_use_critical_trace())
     {
         add_critical_trace<Device::CPU, Phase::DELTA>(
-            threading::get_id(), _cid, 0, _parent_cid, _ts, comp::wall_clock::record(),
+            threading::get_id(), _cid, 0, _parent_cid, _ts, comp::wall_clock::record(), 0,
             reinterpret_cast<uintptr_t>(_mutex), get_hashes().at(_data.index), _depth);
     }
 

--- a/source/lib/omnitrace/library/components/roctracer_callbacks.cpp
+++ b/source/lib/omnitrace/library/components/roctracer_callbacks.cpp
@@ -36,6 +36,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <tuple>
 
 #include <roctracer_ext.h>
 #include <roctracer_hcc.h>
@@ -48,7 +49,8 @@ TIMEMORY_DEFINE_API(roctracer)
 namespace omnitrace
 {
 namespace api = tim::api;
-
+namespace
+{
 int64_t
 get_clock_skew()
 {
@@ -108,6 +110,13 @@ get_clock_skew()
     return (_use) ? _v : 0;
 }
 
+int&
+get_current_device()
+{
+    static thread_local int _v = 1;
+    return _v;
+}
+
 std::unordered_set<uint64_t>&
 get_roctracer_kernels()
 {
@@ -138,12 +147,29 @@ get_roctracer_tid_data()
     return _v;
 }
 
-using cid_tuple_t = std::tuple<uint64_t, uint64_t, uint16_t>;
-std::unordered_map<uint64_t, cid_tuple_t>&
-get_roctracer_cid_data()
+using cid_tuple_t = std::tuple<uint64_t, uint64_t, uint32_t>;
+struct cid_data : cid_tuple_t
 {
-    static auto _v = std::unordered_map<uint64_t, cid_tuple_t>{};
-    return _v;
+    using cid_tuple_t::cid_tuple_t;
+
+    TIMEMORY_DEFAULT_OBJECT(cid_data)
+
+    auto& cid() { return std::get<0>(*this); }
+    auto& pcid() { return std::get<1>(*this); }
+    auto& depth() { return std::get<2>(*this); }
+
+    auto cid() const { return std::get<0>(*this); }
+    auto pcid() const { return std::get<1>(*this); }
+    auto depth() const { return std::get<2>(*this); }
+};
+
+auto&
+get_roctracer_cid_data(int64_t _tid = threading::get_id())
+{
+    using thread_data_t =
+        thread_data<std::unordered_map<uint64_t, cid_data>, api::roctracer>;
+    static auto& _v = thread_data_t::instances(thread_data_t::construct_on_init{});
+    return *_v.at(_tid);
 }
 
 auto&
@@ -156,8 +182,6 @@ get_hip_activity_callbacks(int64_t _tid = threading::get_id())
 
 using hip_activity_mutex_t = std::decay_t<decltype(get_hip_activity_callbacks())>;
 using key_data_mutex_t     = std::decay_t<decltype(get_roctracer_key_data())>;
-using hip_data_mutex_t     = std::decay_t<decltype(get_roctracer_hip_data())>;
-using cid_data_mutex_t     = std::decay_t<decltype(get_roctracer_cid_data())>;
 
 auto&
 get_hip_activity_mutex(int64_t _tid = threading::get_id())
@@ -165,6 +189,7 @@ get_hip_activity_mutex(int64_t _tid = threading::get_id())
     return tim::type_mutex<hip_activity_mutex_t, api::roctracer, max_supported_threads>(
         _tid);
 }
+}  // namespace
 
 // HSA API callback function
 void
@@ -400,7 +425,7 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
     auto      _tid        = threading::get_id();
     uint64_t  _cid        = 0;
     uint64_t  _parent_cid = 0;
-    uint16_t  _depth      = 0;
+    uint32_t  _depth      = 0;
     uintptr_t _queue      = 0;
     auto      _corr_id    = data->correlation_id;
 
@@ -479,8 +504,14 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         default: break;
     }
 
+    auto& _device_id = get_current_device();
+
     if(data->phase == ACTIVITY_API_PHASE_ENTER)
     {
+        if(cid == HIP_API_ID_hipSetDevice)
+            get_current_device() =
+                reinterpret_cast<int>(data->args.hipSetDevice.deviceId) + 1;
+
         const char* _name = nullptr;
         switch(cid)
         {
@@ -545,7 +576,7 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
             TRACE_EVENT_BEGIN(
                 "host", perfetto::StaticString{ op_name }, static_cast<uint64_t>(_ts),
                 perfetto::Flow::ProcessScoped(_cid), "pcid", _parent_cid, "cid", _cid,
-                "tid", _tid, "depth", _depth, "corr_id", _corr_id);
+                "device", _device_id, "tid", _tid, "depth", _depth, "corr_id", _corr_id);
         }
         if(get_use_timemory())
         {
@@ -564,15 +595,12 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         if(get_use_critical_trace() || get_use_rocm_smi())
         {
             add_critical_trace<Device::CPU, Phase::BEGIN>(
-                _tid, _cid, _corr_id, _parent_cid, _ts, 0, _queue,
+                _tid, _cid, _corr_id, _parent_cid, _ts, 0, _device_id, _queue,
                 critical_trace::add_hash_id(op_name), _depth);
         }
 
-        {
-            tim::auto_lock_t _lk{ tim::type_mutex<cid_data_mutex_t>() };
-            get_roctracer_cid_data().emplace(_corr_id,
-                                             cid_tuple_t{ _cid, _parent_cid, _depth });
-        }
+        get_roctracer_cid_data(_tid).emplace(_corr_id,
+                                             cid_data{ _cid, _parent_cid, _depth });
 
         hip_exec_activity_callbacks(_tid);
     }
@@ -580,10 +608,7 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
     {
         hip_exec_activity_callbacks(_tid);
 
-        {
-            tim::auto_lock_t _lk{ tim::type_mutex<cid_data_mutex_t>() };
-            std::tie(_cid, _parent_cid, _depth) = get_roctracer_cid_data().at(_corr_id);
-        }
+        std::tie(_cid, _parent_cid, _depth) = get_roctracer_cid_data(_tid).at(_corr_id);
 
         if(get_use_perfetto())
         {
@@ -613,7 +638,7 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         if(get_use_critical_trace() || get_use_rocm_smi())
         {
             add_critical_trace<Device::CPU, Phase::END>(
-                _tid, _cid, _corr_id, _parent_cid, _ts, _ts, _queue,
+                _tid, _cid, _corr_id, _parent_cid, _ts, _ts, _device_id, _queue,
                 critical_trace::add_hash_id(op_name), _depth);
         }
     }
@@ -677,13 +702,14 @@ hip_activity_callback(const char* begin, const char* end, void*)
         }();
 
         auto& _keys = get_roctracer_key_data();
-        auto& _cids = get_roctracer_cid_data();
         auto& _tids = get_roctracer_tid_data();
 
         int16_t     _depth          = 0;                     // depth of kernel launch
         int64_t     _tid            = 0;                     // thread id
         uint64_t    _cid            = 0;                     // correlation id
         uint64_t    _pcid           = 0;                     // parent corr_id
+        int32_t     _devid          = record->device_id;     // device id
+        int64_t     _queid          = record->queue_id;      // queue id
         auto        _laps           = _indexes[_corr_id]++;  // see note #1
         const char* _name           = nullptr;
         bool        _found          = false;
@@ -705,11 +731,17 @@ hip_activity_callback(const char* begin, const char* end, void*)
 
         if(_critical_trace)
         {
-            tim::auto_lock_t _lk{ tim::type_mutex<cid_data_mutex_t>() };
+            auto& _cids = get_roctracer_cid_data(_tid);
             if(_cids.find(_corr_id) != _cids.end())
                 std::tie(_cid, _pcid, _depth) = _cids.at(_corr_id);
             else
+            {
+                OMNITRACE_VERBOSE_F(3,
+                                    "No critical trace entry generated for \"%s\" :: "
+                                    "unknown correlation id...\n",
+                                    _name);
                 _critical_trace = false;
+            }
         }
 
         {
@@ -719,8 +751,7 @@ hip_activity_callback(const char* begin, const char* end, void*)
                 "%4zu :: %-20s :: %-20s :: correlation_id(%6lu) time_ns(%12lu:%12lu) "
                 "delta_ns(%12lu) device_id(%d) stream_id(%lu) proc_id(%u) thr_id(%lu)\n",
                 _n++, op_name, _name, record->correlation_id, _beg_ns, _end_ns,
-                (_end_ns - _beg_ns), record->device_id, record->queue_id,
-                record->process_id, _tid);
+                (_end_ns - _beg_ns), _devid, _queid, record->process_id, _tid);
         }
 
         // execute this on this thread bc of how perfetto visualization works
@@ -733,11 +764,11 @@ hip_activity_callback(const char* begin, const char* end, void*)
                 _kernel_names.emplace(_name, tim::demangle(_name));
 
             assert(_end_ns > _beg_ns);
-            TRACE_EVENT_BEGIN(
-                "device", perfetto::StaticString{ _kernel_names.at(_name).c_str() },
-                _beg_ns, perfetto::Flow::ProcessScoped(_cid), "corr_id",
-                record->correlation_id, "device", record->device_id, "queue",
-                record->queue_id, "op", _op_id_names.at(record->op));
+            TRACE_EVENT_BEGIN("device",
+                              perfetto::StaticString{ _kernel_names.at(_name).c_str() },
+                              _beg_ns, perfetto::Flow::ProcessScoped(_cid), "corr_id",
+                              record->correlation_id, "device", _devid, "queue", _queid,
+                              "op", _op_id_names.at(record->op));
             TRACE_EVENT_END("device", _end_ns);
             // for some reason, this is necessary to make sure very last one ends
             TRACE_EVENT_END("device", _end_ns);
@@ -748,7 +779,7 @@ hip_activity_callback(const char* begin, const char* end, void*)
             auto     _hash = critical_trace::add_hash_id(_name);
             uint16_t _prio = _laps + 1;  // priority
             add_critical_trace<Device::GPU, Phase::DELTA, false>(
-                _tid, _cid, _corr_id, _cid, _beg_ns, _end_ns, record->queue_id, _hash,
+                _tid, _cid, _corr_id, _cid, _beg_ns, _end_ns, _devid, _queid, _hash,
                 _depth + 1, _prio);
         }
 

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -690,7 +690,7 @@ print_settings(
 }
 
 void
-print_settings()
+print_settings(bool _include_env)
 {
     if(dmp::rank() > 0) return;
 
@@ -699,9 +699,12 @@ print_settings()
         return (_v.find("OMNITRACE_") == 0);
     };
 
-    tim::print_env(std::cerr, [_is_omnitrace_option](const std::string& _v) {
-        return _is_omnitrace_option(_v, std::set<std::string>{});
-    });
+    if(_include_env)
+    {
+        tim::print_env(std::cerr, [_is_omnitrace_option](const std::string& _v) {
+            return _is_omnitrace_option(_v, std::set<std::string>{});
+        });
+    }
 
     print_settings(std::cerr, _is_omnitrace_option);
 

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -57,7 +57,7 @@ print_settings(
     std::function<bool(const std::string_view&, const std::set<std::string>&)>&& _filter);
 
 void
-print_settings();
+print_settings(bool include_env = true);
 
 std::string&
 get_exe_name();

--- a/source/lib/omnitrace/library/runtime.cpp
+++ b/source/lib/omnitrace/library/runtime.cpp
@@ -94,7 +94,7 @@ get_cpu_cid_parents(int64_t _tid)
     return _v.at(_tid);
 }
 
-std::tuple<uint64_t, uint64_t, uint16_t>
+std::tuple<uint64_t, uint64_t, uint32_t>
 create_cpu_cid_entry(int64_t _tid)
 {
     using tim::auto_lock_t;
@@ -114,7 +114,7 @@ create_cpu_cid_entry(int64_t _tid)
 
     auto&&     _cid        = get_cpu_cid()++;
     auto&&     _parent_cid = get_cpu_cid_stack(_p_idx)->back();
-    uint16_t&& _depth = get_cpu_cid_stack(_p_idx)->size() - ((_p_idx == _tid) ? 1 : 0);
+    uint32_t&& _depth = get_cpu_cid_stack(_p_idx)->size() - ((_p_idx == _tid) ? 1 : 0);
 
     get_cpu_cid_parents(_tid)->emplace(_cid, std::make_tuple(_parent_cid, _depth));
     return std::make_tuple(_cid, _parent_cid, _depth);

--- a/source/lib/omnitrace/library/runtime.hpp
+++ b/source/lib/omnitrace/library/runtime.hpp
@@ -73,8 +73,8 @@ get_cpu_cid();
 unique_ptr_t<std::vector<uint64_t>>&
 get_cpu_cid_stack(int64_t _tid = threading::get_id(), int64_t _parent = 0);
 
-using cpu_cid_data_t       = std::tuple<uint64_t, uint64_t, uint16_t>;
-using cpu_cid_pair_t       = std::tuple<uint64_t, uint16_t>;
+using cpu_cid_data_t       = std::tuple<uint64_t, uint64_t, uint32_t>;
+using cpu_cid_pair_t       = std::tuple<uint64_t, uint32_t>;
 using cpu_cid_parent_map_t = std::unordered_map<uint64_t, cpu_cid_pair_t>;
 
 unique_ptr_t<cpu_cid_parent_map_t>&


### PR DESCRIPTION
- better handling of OMNITRACE_USE_PERFETTO in omnitrace-critical-trace exe
- changed some data types in `critical_trace::entry`
- added device ids to critical trace entries
- added process ids to critical trace entries
- added packing to critical trace entries
