### PR TITLE
Fix loop-level instrumentation + more

### DIFF
--- a/examples/transpose/transpose.cpp
+++ b/examples/transpose/transpose.cpp
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include <iomanip>
 #include <iostream>
 #include <mutex>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -106,12 +107,15 @@ run(int rank, int tid, hipStream_t stream, int argc, char** argv)
     std::cout << "[" << rank << "][" << tid << "] M: " << M << " N: " << N << std::endl;
     _lk.unlock();
 
+    std::default_random_engine _engine{ std::random_device{}() * (rank + 1) * (tid + 1) };
+    std::uniform_int_distribution<int> _dist{ 0, 1000 };
+
     size_t size       = sizeof(int) * M * N;
     int*   inp_matrix = new int[size];
     int*   out_matrix = new int[size];
     for(size_t i = 0; i < M * N; i++)
     {
-        inp_matrix[i] = rand() % 1002;
+        inp_matrix[i] = _dist(_engine);
         out_matrix[i] = 0;
     }
     int* in  = nullptr;

--- a/source/bin/omnitrace/details.cpp
+++ b/source/bin/omnitrace/details.cpp
@@ -529,11 +529,9 @@ are_file_include_exclude_lists_empty()
 //  the instrumented loop and formats it properly.
 //
 function_signature
-get_loop_file_line_info(module_t* module, procedure_t* func, flow_graph_t* cfGraph,
+get_loop_file_line_info(module_t* module, procedure_t* func, flow_graph_t*,
                         basic_loop_t* loopToInstrument)
 {
-    if(!cfGraph || !loopToInstrument || !func) return function_signature{ "", "", "" };
-
     std::vector<BPatch_basicBlock*> basic_blocks{};
     loopToInstrument->getLoopBasicBlocksExclusive(basic_blocks);
 
@@ -563,7 +561,7 @@ get_loop_file_line_info(module_t* module, procedure_t* func, flow_graph_t* cfGra
     memset(fname, '\0', FUNCNAMELEN + 1);
     memset(mname, '\0', FUNCNAMELEN + 1);
 
-    module->getName(mname, FUNCNAMELEN);
+    module->getFullName(mname, FUNCNAMELEN);
     func->getName(fname, FUNCNAMELEN);
 
     auto* returnType = func->getReturnType();
@@ -641,7 +639,8 @@ get_loop_file_line_info(module_t* module, procedure_t* func, flow_graph_t* cfGra
     }
     else
     {
-        return function_signature(typeName, fname, filename, _params);
+        return function_signature(typeName, fname, filename, _params, { 0, 0 }, { 0, 0 },
+                                  true, false, false);
     }
 }
 
@@ -661,7 +660,7 @@ get_func_file_line_info(module_t* module, procedure_t* func)
     memset(fname, '\0', FUNCNAMELEN + 1);
     memset(mname, '\0', FUNCNAMELEN + 1);
 
-    module->getName(mname, FUNCNAMELEN);
+    module->getFullName(mname, FUNCNAMELEN);
     func->getName(fname, FUNCNAMELEN);
 
     address_t base_addr{};
@@ -727,7 +726,7 @@ get_basic_block_file_line_info(module_t* module, procedure_t* func)
     memset(fname, '\0', FUNCNAMELEN + 1);
     memset(mname, '\0', FUNCNAMELEN + 1);
 
-    module->getName(mname, FUNCNAMELEN);
+    module->getFullName(mname, FUNCNAMELEN);
     func->getName(fname, FUNCNAMELEN);
 
     auto* returnType = func->getReturnType();

--- a/source/bin/omnitrace/function_signature.cpp
+++ b/source/bin/omnitrace/function_signature.cpp
@@ -67,7 +67,7 @@ function_signature::get(bool _all, bool _save) const
     if((_all || use_return_info) && !m_return.empty()) ss << m_return << " ";
     ss << m_name;
     if(_all || use_args_info) ss << m_params;
-    if(m_loop && m_info_beg)
+    if(m_loop)
     {
         auto _row_col_str = [](unsigned long _row, unsigned long _col) {
             std::stringstream _ss{};
@@ -89,8 +89,11 @@ function_signature::get(bool _all, bool _save) const
             ss << " [" << _rc1 << "]";
         else if(!m_info_end && !_rc1.empty())
             ss << " [" << _rc1 << "]";
+        else if(m_loop_num < std::numeric_limits<uint32_t>::max())
+            ss << " [loop#" << m_loop_num << "]";
         else
-            errprintf(3, "line info for %s is empty!\n", m_name.c_str());
+            errprintf(3, "line info for %s is empty! [{%s}] [{%s}]\n", m_name.c_str(),
+                      _rc1.c_str(), _rc2.c_str());
     }
     if((_all || use_file_info) && m_file.length() > 0) ss << " [" << m_file;
     if((_all || use_line_info) && m_row.first > 0) ss << ":" << m_row.first;

--- a/source/bin/omnitrace/function_signature.hpp
+++ b/source/bin/omnitrace/function_signature.hpp
@@ -40,6 +40,12 @@ struct function_signature
                        location_t _col = { 0, 0 }, bool _loop = false,
                        bool _info_beg = false, bool _info_end = false);
 
+    function_signature& set_loop_number(uint32_t _n)
+    {
+        m_loop_num = _n;
+        return *this;
+    }
+
     static string_t get(function_signature& sig);
     string_t        get(bool _all = false, bool _save = true) const;
     string_t        get_coverage(bool _is_basic_block) const;
@@ -47,6 +53,7 @@ struct function_signature
     bool             m_loop      = false;
     bool             m_info_beg  = false;
     bool             m_info_end  = false;
+    uint32_t         m_loop_num  = std::numeric_limits<uint32_t>::max();
     location_t       m_row       = { 0, 0 };
     location_t       m_col       = { 0, 0 };
     string_t         m_return    = {};

--- a/source/bin/omnitrace/module_function.hpp
+++ b/source/bin/omnitrace/module_function.hpp
@@ -98,7 +98,7 @@ struct module_function
     basic_loop_vec_t                        loop_blocks      = {};
     std::vector<std::vector<instruction_t>> instructions     = {};
 
-    using str_msg_t     = std::tuple<int, string_t, string_t, string_t>;
+    using str_msg_t     = std::tuple<int, string_t, string_t, string_t, string_t>;
     using str_msg_vec_t = std::vector<str_msg_t>;
 
     mutable str_msg_vec_t messages = {};
@@ -183,6 +183,8 @@ module_function::serialize(ArchiveT& ar, const unsigned)
 
     if constexpr(tim::concepts::is_output_archive<ArchiveT>::value)
     {
+        ar(cereal::make_nvp("num_basic_blocks", basic_blocks.size()),
+           cereal::make_nvp("num_outer_loops", loop_blocks.size()));
         ar.setNextName("heuristics");
         ar.startNode();
         ar(cereal::make_nvp("should_instrument", should_instrument()),
@@ -202,10 +204,12 @@ module_function::serialize(ArchiveT& ar, const unsigned)
            cereal::make_nvp("is_dynamic_callsite_forced", is_dynamic_callsite_forced()),
            cereal::make_nvp("is_address_range_constrained",
                             is_address_range_constrained()),
+           cereal::make_nvp("is_num_instructions_constrained",
+                            is_num_instructions_constrained()),
            cereal::make_nvp("is_loop_address_range_constrained",
                             is_loop_address_range_constrained()),
-           cereal::make_nvp("is_num_instructions_constrained",
-                            is_num_instructions_constrained()));
+           cereal::make_nvp("is_loop_num_instructions_constrained",
+                            is_loop_num_instructions_constrained()));
         ar.finishNode();
         // instructions can inflate JSON size so only output when verbosity is increased
         // above default

--- a/source/bin/omnitrace/omnitrace.hpp
+++ b/source/bin/omnitrace/omnitrace.hpp
@@ -331,6 +331,7 @@ insert_instr(address_space_t* mutatee, procedure_t* funcToInstr, Tp traceFunc,
     bpvector_t<point_t*>* _points = nullptr;
     auto                  _trace  = traceFunc.get();
 
+    if(!cfGraph) funcToInstr->getCFG();
     if(cfGraph && loopToInstrument)
     {
         if(traceLoc == BPatch_entry)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -406,9 +406,42 @@ omnitrace_add_test(
     TARGET transpose
     MPI ${TRANSPOSE_USE_MPI}
     NUM_PROCS ${NUM_PROCS}
-    REWRITE_ARGS -e -v 2 --print-instructions
-    RUNTIME_ARGS -e -v 1 --label file line return args
+    REWRITE_ARGS -e -v 2 --print-instructions -E uniform_int_distribution
+    RUNTIME_ARGS
+        -e
+        -v
+        1
+        --label
+        file
+        line
+        return
+        args
+        -E
+        uniform_int_distribution
     ENVIRONMENT "${_base_environment};OMNITRACE_CRITICAL_TRACE=ON")
+
+omnitrace_add_test(
+    SKIP_BASELINE SKIP_SAMPLING SKIP_RUNTIME
+    NAME transpose-loops
+    TARGET transpose
+    LABELS "loops"
+    MPI ${TRANSPOSE_USE_MPI}
+    NUM_PROCS ${NUM_PROCS}
+    REWRITE_ARGS
+        -e
+        -v
+        2
+        --label
+        return
+        args
+        -l
+        -i
+        8
+        -E
+        uniform_int_distribution
+    RUN_ARGS 2 100 50
+    ENVIRONMENT "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure transpose")
 
 omnitrace_add_test(
     NAME parallel-overhead
@@ -454,6 +487,7 @@ omnitrace_add_test(
 omnitrace_add_test(
     NAME user-api
     TARGET user-api
+    LABELS "loops"
     REWRITE_ARGS -e -v 2 -l --min-instructions=8 -E custom_push_region
     RUNTIME_ARGS
         -e
@@ -469,7 +503,8 @@ omnitrace_add_test(
         return
         args
     RUN_ARGS 10 ${NUM_THREADS} 1000
-    ENVIRONMENT "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF")
+    ENVIRONMENT "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure")
 
 omnitrace_add_test(
     SKIP_RUNTIME
@@ -553,7 +588,7 @@ omnitrace_add_test(
     TARGET lulesh
     MPI ${LULESH_USE_MPI}
     NUM_PROCS 8
-    LABELS "kokkos"
+    LABELS "kokkos;loops"
     REWRITE_ARGS -e -v 2
     RUNTIME_ARGS
         -e
@@ -575,7 +610,7 @@ omnitrace_add_test(
     TARGET lulesh
     MPI ${LULESH_USE_MPI}
     NUM_PROCS 8
-    LABELS "kokkos"
+    LABELS "kokkos;loops"
     REWRITE_ARGS -e -v 2 -l --dynamic-callsites --traps --allow-overlapping
     RUNTIME_ARGS
         -e
@@ -590,7 +625,8 @@ omnitrace_add_test(
         peak_rss
     RUN_ARGS -i 10 -s 20 -p
     ENVIRONMENT
-        "${_timemory_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=OFF")
+        "${_timemory_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=OFF"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure")
 
 omnitrace_add_test(
     SKIP_SAMPLING
@@ -601,7 +637,8 @@ omnitrace_add_test(
     RUNTIME_ARGS -e -v 1 --label return args
     REWRITE_TIMEOUT 180
     RUNTIME_TIMEOUT 360
-    ENVIRONMENT "${_ompt_environment};OMNITRACE_USE_SAMPLING=OFF")
+    ENVIRONMENT "${_ompt_environment};OMNITRACE_USE_SAMPLING=OFF"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure")
 
 omnitrace_add_test(
     SKIP_RUNTIME
@@ -613,7 +650,8 @@ omnitrace_add_test(
     REWRITE_TIMEOUT 180
     RUNTIME_TIMEOUT 360
     ENVIRONMENT
-        "${_ompt_environment};OMNITRACE_USE_SAMPLING=ON;OMNITRACE_SAMPLING_FREQ=100")
+        "${_ompt_environment};OMNITRACE_USE_SAMPLING=ON;OMNITRACE_SAMPLING_FREQ=100"
+    REWRITE_FAIL_REGEX "0 instrumented loops in procedure")
 
 omnitrace_add_test(
     SKIP_BASELINE SKIP_SAMPLING


### PR DESCRIPTION
- fix loop-level instrumentation
  - Closes #21 
- support loop instrumentation w/o debug symbols via loop number
- improve module_function messages
- serialize num_basic_blocks
- serialize num_outer_loops
- serialize is_num_instructions_constrained
- serialize is_loop_num_instructions_constrained
- updated transpose example to use uniform_int_distribution
  - this resulted in a speedup of ~2x
  - instrumentation was slowed down significantly in binary rewrite due to instrumentation of `uniform_int_distribution::operator()` and thus tests using transpose exe use `-E uniform_int_distribution`
- added transpose loop test
- added fail regexes for tests which enable loop instrumentation
- replace `module->getName` with `module->getFullName` in:
  - `get_loop_file_line_info(...)` in details.cpp
  - `get_func_file_line_info(...)` in details.cpp
  - `get_basic_block_file_line_info(...)` in details.cpp

Issue with loop-level instrumentation was due to `_is_constrained` lambda testing for `_v == false` after being passed `_points == 0` instead of `_v == true`:

```cpp
        auto _is_constrained = [this](bool _v, const std::string& _label) {
            if(!_v)
            {
                messages.emplace_back(3, "Skipping", "function", _label);
                return true;
            }
            return false;
        };


        size_t _points             = 0;
        size_t _ntraps             = 0;
        std::tie(_points, _ntraps) = query_instr(function, BPatch_entry, flow_graph, itr);

        if(_is_constrained(_points == 0, "no-instrumentable-loop-entry-point")) continue;
```

Effectively, since there `_points` was always > 0, this resulted in `_is_constrained` always returning true. 