### PR TITLE
Fix sampling counter time scales

### DIFF
--- a/source/lib/omnitrace/library/components/backtrace.hpp
+++ b/source/lib/omnitrace/library/components/backtrace.hpp
@@ -28,7 +28,6 @@
 #include "library/thread_data.hpp"
 #include "library/timemory.hpp"
 
-#include <bits/stdint-uintn.h>
 #include <timemory/components/base.hpp>
 #include <timemory/components/papi/papi_array.hpp>
 #include <timemory/components/papi/types.hpp>

--- a/source/lib/omnitrace/library/components/backtrace.hpp
+++ b/source/lib/omnitrace/library/components/backtrace.hpp
@@ -28,6 +28,7 @@
 #include "library/thread_data.hpp"
 #include "library/timemory.hpp"
 
+#include <bits/stdint-uintn.h>
 #include <timemory/components/base.hpp>
 #include <timemory/components/papi/papi_array.hpp>
 #include <timemory/components/papi/types.hpp>
@@ -57,7 +58,6 @@ struct backtrace
 
     using data_t            = std::array<char[buffer_width], stack_depth>;
     using clock_type        = std::chrono::steady_clock;
-    using time_point_type   = typename clock_type::time_point;
     using value_type        = void;
     using hw_counters       = tim::component::papi_array<num_hw_counters>;
     using hw_counter_data_t = typename hw_counters::value_type;
@@ -88,7 +88,7 @@ struct backtrace
     bool                     empty() const;
     size_t                   size() const;
     std::vector<std::string> get() const;
-    time_point_type          get_timestamp() const;
+    uint64_t                 get_timestamp() const;
     int64_t                  get_thread_cpu_timestamp() const;
 
 private:
@@ -97,8 +97,8 @@ private:
     int64_t           m_mem_peak   = 0;
     int64_t           m_ctx_swch   = 0;
     int64_t           m_page_flt   = 0;
+    uint64_t          m_ts         = {};
     size_t            m_size       = 0;
-    time_point_type   m_ts         = {};
     data_t            m_data       = {};
     hw_counter_data_t m_hw_counter = {};
 };

--- a/source/lib/omnitrace/library/components/roctracer_callbacks.cpp
+++ b/source/lib/omnitrace/library/components/roctracer_callbacks.cpp
@@ -276,8 +276,10 @@ hsa_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
                 if(get_use_perfetto())
                 {
                     TRACE_EVENT_BEGIN("device", perfetto::StaticString{ _name },
+                                      static_cast<uint64_t>(begin_timestamp), "begin_ns",
                                       static_cast<uint64_t>(begin_timestamp));
-                    TRACE_EVENT_END("device", static_cast<uint64_t>(end_timestamp));
+                    TRACE_EVENT_END("device", static_cast<uint64_t>(end_timestamp),
+                                    "end_ns", static_cast<uint64_t>(end_timestamp));
                 }
 
                 if(get_use_timemory())
@@ -347,8 +349,10 @@ hsa_activity_callback(uint32_t op, activity_record_t* record, void* arg)
         if(get_use_perfetto())
         {
             TRACE_EVENT_BEGIN("device", perfetto::StaticString{ *_name },
+                              static_cast<uint64_t>(_beg_ns), "begin_ns",
                               static_cast<uint64_t>(_beg_ns));
-            TRACE_EVENT_END("device", static_cast<uint64_t>(_end_ns));
+            TRACE_EVENT_END("device", static_cast<uint64_t>(_end_ns), "end_ns",
+                            static_cast<uint64_t>(_end_ns));
         }
         if(get_use_timemory())
         {
@@ -579,8 +583,9 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         {
             TRACE_EVENT_BEGIN(
                 "host", perfetto::StaticString{ op_name }, static_cast<uint64_t>(_ts),
-                perfetto::Flow::ProcessScoped(_cid), "pcid", _parent_cid, "cid", _cid,
-                "device", _device_id, "tid", _tid, "depth", _depth, "corr_id", _corr_id);
+                perfetto::Flow::ProcessScoped(_cid), "begin_ns",
+                static_cast<uint64_t>(_ts), "pcid", _parent_cid, "cid", _cid, "device",
+                _device_id, "tid", _tid, "depth", _depth, "corr_id", _corr_id);
         }
         if(get_use_timemory())
         {
@@ -616,7 +621,8 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
 
         if(get_use_perfetto())
         {
-            TRACE_EVENT_END("host", static_cast<uint64_t>(_ts));
+            TRACE_EVENT_END("host", static_cast<uint64_t>(_ts), "end_ns",
+                            static_cast<uint64_t>(_ts));
         }
         if(get_use_timemory())
         {
@@ -774,12 +780,12 @@ hip_activity_callback(const char* begin, const char* end, void*)
             assert(_end_ns > _beg_ns);
             TRACE_EVENT_BEGIN("device",
                               perfetto::StaticString{ _kernel_names.at(_name).c_str() },
-                              _beg_ns, perfetto::Flow::ProcessScoped(_cid), "corr_id",
-                              record->correlation_id, "device", _devid, "queue", _queid,
-                              "op", _op_id_names.at(record->op));
-            TRACE_EVENT_END("device", _end_ns);
+                              _beg_ns, perfetto::Flow::ProcessScoped(_cid), "begin_ns",
+                              _beg_ns, "corr_id", record->correlation_id, "device",
+                              _devid, "queue", _queid, "op", _op_id_names.at(record->op));
+            TRACE_EVENT_END("device", _end_ns, "end_ns", _end_ns);
             // for some reason, this is necessary to make sure very last one ends
-            TRACE_EVENT_END("device", _end_ns);
+            TRACE_EVENT_END("device", _end_ns, "end_ns", _end_ns);
         }
 
         if(_critical_trace)

--- a/source/lib/omnitrace/library/critical_trace.cpp
+++ b/source/lib/omnitrace/library/critical_trace.cpp
@@ -434,14 +434,17 @@ call_chain::generate_perfetto<Device::NONE>(std::set<entry>& _used) const
         if(itr.device == Device::CPU)
         {
             TRACE_EVENT_BEGIN("device-critical-trace", "CPU",
-                              static_cast<uint64_t>(itr.begin_ns));
+                              static_cast<uint64_t>(itr.begin_ns), "begin_ns",
+                              itr.begin_ns);
         }
         else if(itr.device == Device::GPU)
         {
             TRACE_EVENT_BEGIN("device-critical-trace", "GPU",
-                              static_cast<uint64_t>(itr.begin_ns));
+                              static_cast<uint64_t>(itr.begin_ns), "begin_ns",
+                              itr.begin_ns);
         }
-        TRACE_EVENT_END("device-critical-trace", static_cast<uint64_t>(itr.end_ns));
+        TRACE_EVENT_END("device-critical-trace", static_cast<uint64_t>(itr.end_ns),
+                        "end_ns", itr.end_ns);
     }
 }
 
@@ -462,8 +465,10 @@ call_chain::generate_perfetto<Device::CPU>(std::set<entry>& _used) const
         _static_mutex.unlock();
         TRACE_EVENT_BEGIN("host-critical-trace",
                           perfetto::StaticString{ sitr.first->c_str() },
+                          static_cast<uint64_t>(itr.begin_ns), "begin_ns",
                           static_cast<uint64_t>(itr.begin_ns));
-        TRACE_EVENT_END("host-critical-trace", static_cast<uint64_t>(itr.end_ns));
+        TRACE_EVENT_END("host-critical-trace", static_cast<uint64_t>(itr.end_ns),
+                        "end_ns", static_cast<uint64_t>(itr.end_ns));
     }
 }
 
@@ -484,8 +489,10 @@ call_chain::generate_perfetto<Device::GPU>(std::set<entry>& _used) const
         _static_mutex.unlock();
         TRACE_EVENT_BEGIN("device-critical-trace",
                           perfetto::StaticString{ sitr.first->c_str() },
+                          static_cast<uint64_t>(itr.begin_ns), "begin_ns",
                           static_cast<uint64_t>(itr.begin_ns));
-        TRACE_EVENT_END("device-critical-trace", static_cast<uint64_t>(itr.end_ns));
+        TRACE_EVENT_END("device-critical-trace", static_cast<uint64_t>(itr.end_ns),
+                        "end_ns", static_cast<uint64_t>(itr.end_ns));
     }
 }
 
@@ -504,8 +511,10 @@ call_chain::generate_perfetto<Device::ANY>(std::set<entry>& _used) const
         auto sitr = _static_strings.emplace(_name);
         _static_mutex.unlock();
         TRACE_EVENT_BEGIN("critical-trace", perfetto::StaticString{ sitr.first->c_str() },
+                          static_cast<uint64_t>(itr.begin_ns), "begin_ns",
                           static_cast<uint64_t>(itr.begin_ns));
-        TRACE_EVENT_END("critical-trace", static_cast<uint64_t>(itr.end_ns));
+        TRACE_EVENT_END("critical-trace", static_cast<uint64_t>(itr.end_ns), "end_ns",
+                        static_cast<uint64_t>(itr.end_ns));
     }
 }
 


### PR DESCRIPTION
This PR fixes some issues with the timestamps of samples being before started before and after the "main" in perfetto. This pseudo-bug was introduced in PR #30 

- All perfetto trace events have "begin_ns" and "end_ns" debug fields
- data for thread start and end timestamp in pthread_create_gotcha
- discard samples outside of thread start and end timestamps
- rename "CPU User CPU Time" perfetto counter to "CPU User Time"
- rename "CPU Kernel CPU Time" perfetto counter to "CPU Kernel Time"
- ensure CPU system samples in perfetto are set to zero at end
- backtrace uses comp::wall_clock record() for timestamps (consistency)
- "Peak Memory Usage [Thread X] (S)" renamed to "Thread Peak Memory Usage [X] (S)"
- "Context Switches [Thread X] (S)" renamed to "Thread Context Switches Usage [X] (S)"
- "Page Faults [Thread X] (S)" renamed to "Thread Page Faults Usage [X] (S)"
- "<PAPI_DESC> [Thread X] (S)" renamed to "Thread <PAPI_DESC> [X] (S)"
