### PR TITLE
Fixes excluded-instr output, fini functions, tweaks MPI

### DIFF
--- a/cmake/Packages.cmake
+++ b/cmake/Packages.cmake
@@ -157,6 +157,8 @@ endif()
 if(OMNITRACE_USE_MPI)
     find_package(MPI ${omnitrace_FIND_QUIETLY} REQUIRED)
     target_link_libraries(omnitrace-mpi INTERFACE MPI::MPI_C MPI::MPI_CXX)
+    omnitrace_target_compile_definitions(omnitrace-mpi INTERFACE TIMEMORY_USE_MPI=1
+                                                                 OMNITRACE_USE_MPI)
 elseif(OMNITRACE_USE_MPI_HEADERS)
     find_package(MPI-Headers ${omnitrace_FIND_QUIETLY} REQUIRED)
     omnitrace_target_compile_definitions(

--- a/source/bin/tests/CMakeLists.txt
+++ b/source/bin/tests/CMakeLists.txt
@@ -104,8 +104,10 @@ omnitrace_add_bin_test(
          xml
          -v
          1
+         --all-functions
          --
          ls
+    LABELS "simulate"
     TIMEOUT 120)
 
 omnitrace_add_bin_test(


### PR DESCRIPTION
- fixes population of excluded_module_functions
- omnitrace-compile-definitions have OMNITRACE_USE_MPI and OMNITRACE_USE_MPI_HEADERS
- Do not enable mpi support if no full or partial MPI support
- New option --all-functions
- Closes #49 