### PR TITLE
Remove reliance on MPI_Comm_rank

### DIFF
--- a/source/lib/omnitrace/CMakeLists.txt
+++ b/source/lib/omnitrace/CMakeLists.txt
@@ -61,6 +61,7 @@ set(library_sources
     ${CMAKE_CURRENT_LIST_DIR}/library/dynamic_library.cpp
     ${CMAKE_CURRENT_LIST_DIR}/library/kokkosp.cpp
     ${CMAKE_CURRENT_LIST_DIR}/library/gpu.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/library/mproc.cpp
     ${CMAKE_CURRENT_LIST_DIR}/library/ompt.cpp
     ${CMAKE_CURRENT_LIST_DIR}/library/perfetto.cpp
     ${CMAKE_CURRENT_LIST_DIR}/library/ptl.cpp
@@ -90,6 +91,7 @@ set(library_headers
     ${CMAKE_CURRENT_LIST_DIR}/library/debug.hpp
     ${CMAKE_CURRENT_LIST_DIR}/library/dynamic_library.hpp
     ${CMAKE_CURRENT_LIST_DIR}/library/gpu.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/library/mproc.hpp
     ${CMAKE_CURRENT_LIST_DIR}/library/ompt.hpp
     ${CMAKE_CURRENT_LIST_DIR}/library/perfetto.hpp
     ${CMAKE_CURRENT_LIST_DIR}/library/ptl.hpp

--- a/source/lib/omnitrace/library/mproc.cpp
+++ b/source/lib/omnitrace/library/mproc.cpp
@@ -1,0 +1,74 @@
+// MIT License
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "library/mproc.hpp"
+#include "library/debug.hpp"
+#include "library/timemory.hpp"
+
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+
+namespace omnitrace
+{
+namespace mproc
+{
+std::set<int>
+get_concurrent_processes(int _ppid)
+{
+    std::set<int> _children = {};
+    if(_ppid > 0)
+    {
+        auto          _inp = JOIN('/', "/proc", _ppid, "task", _ppid, "children");
+        std::ifstream _ifs{ _inp };
+        if(!_ifs)
+        {
+            OMNITRACE_VERBOSE_F(0, "Warning! File '%s' cannot be read\n", _inp.c_str());
+            return _children;
+        }
+
+        while(_ifs)
+        {
+            int _v = -1;
+            _ifs >> _v;
+            if(!_ifs.good() || _ifs.eof()) break;
+            if(_v < 0) continue;
+            _children.emplace(_v);
+        }
+    }
+    return _children;
+}
+
+int
+get_process_index(int _pid, int _ppid)
+{
+    auto _children = get_concurrent_processes(_ppid);
+    for(auto itr = _children.begin(); itr != _children.end(); ++itr)
+    {
+        if(*itr == _pid) return std::distance(_children.begin(), itr);
+    }
+    return -1;
+}
+}  // namespace mproc
+}  // namespace omnitrace

--- a/source/lib/omnitrace/library/mproc.hpp
+++ b/source/lib/omnitrace/library/mproc.hpp
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <set>
+#include <unistd.h>
+
+namespace omnitrace
+{
+namespace mproc
+{
+// get the concurrent processes from /proc/<PPID>/task/<PPID>/children
+std::set<int>
+get_concurrent_processes(int _ppid = getppid());
+
+int
+get_process_index(int _pid = getpid(), int _ppid = getppid());
+}  // namespace mproc
+}  // namespace omnitrace


### PR DESCRIPTION
- read `/proc/<PID>/tasks/<PID>/children` of parent process to deduce the rank
- Old format relied on user calling `MPI_Comm_rank(MPI_COMM_WORLD, ...)`
- if `MPI_Comm_rank` called with subcommunicators only, multiple ranks would write to same file