### PR TITLE
libomnitrace uses common headers

### DIFF
--- a/source/lib/common/CMakeLists.txt
+++ b/source/lib/common/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 add_library(omnitrace-common-library INTERFACE)
 add_library(omnitrace::common-library ALIAS omnitrace-common-library)
+add_library(omnitrace::omnitrace-common-library ALIAS omnitrace-common-library)
 
 target_sources(
     omnitrace-common-library
@@ -17,6 +18,7 @@ target_sources(
 
 get_filename_component(COMMON_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" DIRECTORY)
 
-target_include_directories(omnitrace-common-library INTERFACE ${COMMON_INCLUDE_DIR})
+target_include_directories(omnitrace-common-library
+                           INTERFACE $<BUILD_INTERFACE:${COMMON_INCLUDE_DIR}>)
 target_compile_definitions(omnitrace-common-library
                            INTERFACE $<BUILD_INTERFACE:OMNITRACE_INTERNAL_BUILD=1>)

--- a/source/lib/common/defines.h
+++ b/source/lib/common/defines.h
@@ -22,12 +22,38 @@
 
 #pragma once
 
-#define OMNITRACE_ATTRIBUTE(...)   __attribute__((__VA_ARGS__))
-#define OMNITRACE_VISIBILITY(MODE) OMNITRACE_ATTRIBUTE(visibility(MODE))
-#define OMNITRACE_PUBLIC_API       OMNITRACE_VISIBILITY("default")
-#define OMNITRACE_HIDDEN_API       OMNITRACE_VISIBILITY("hidden")
-#define OMNITRACE_WEAK_API         OMNITRACE_ATTRIBUTE(weak)
-#define OMNITRACE_INLINE           OMNITRACE_ATTRIBUTE(__always_inline__)
+#define OMNITRACE_ATTRIBUTE(...)    __attribute__((__VA_ARGS__))
+#define OMNITRACE_VISIBILITY(MODE)  OMNITRACE_ATTRIBUTE(visibility(MODE))
+#define OMNITRACE_PUBLIC_API        OMNITRACE_VISIBILITY("default")
+#define OMNITRACE_HIDDEN_API        OMNITRACE_VISIBILITY("hidden")
+#define OMNITRACE_INLINE            OMNITRACE_ATTRIBUTE(always_inline) inline
+#define OMNITRACE_NOINLINE          OMNITRACE_ATTRIBUTE(noinline)
+#define OMNITRACE_HOT               OMNITRACE_ATTRIBUTE(hot)
+#define OMNITRACE_CONST             OMNITRACE_ATTRIBUTE(const)
+#define OMNITRACE_PURE              OMNITRACE_ATTRIBUTE(pure)
+#define OMNITRACE_PACKED            OMNITRACE_ATTRIBUTE(__packed__)
+#define OMNITRACE_PACKED_ALIGN(VAL) OMNITRACE_PACKED OMNITRACE_ATTRIBUTE(__aligned__(VAL))
+
+#if defined(OMNITRACE_CI) && OMNITRACE_CI > 0
+#    if defined(NDEBUG)
+#        undef NDEBUG
+#    endif
+#    if !defined(DEBUG)
+#        define DEBUG 1
+#    endif
+#    if defined(__cplusplus)
+#        include <cassert>
+#    else
+#        include <assert.h>
+#    endif
+#endif
+
+#define OMNITRACE_STRINGIZE(X)           OMNITRACE_STRINGIZE2(X)
+#define OMNITRACE_STRINGIZE2(X)          #X
+#define OMNITRACE_VAR_NAME_COMBINE(X, Y) X##Y
+#define OMNITRACE_VARIABLE(Y)            OMNITRACE_VAR_NAME_COMBINE(_omni_var_, Y)
+#define OMNITRACE_LINESTR                OMNITRACE_STRINGIZE(__LINE__)
+#define OMNITRACE_ESC(...)               __VA_ARGS__
 
 #if defined(__cplusplus)
 #    if !defined(OMNITRACE_FOLD_EXPRESSION)

--- a/source/lib/omnitrace/CMakeLists.txt
+++ b/source/lib/omnitrace/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
     INTERFACE
         $<BUILD_INTERFACE:omnitrace::omnitrace-headers>
         $<BUILD_INTERFACE:omnitrace::omnitrace-threading>
+        $<BUILD_INTERFACE:omnitrace::omnitrace-common-library>
         $<BUILD_INTERFACE:omnitrace::omnitrace-compile-options>
         $<BUILD_INTERFACE:omnitrace::omnitrace-compile-definitions>
         $<BUILD_INTERFACE:omnitrace::omnitrace-perfetto>

--- a/source/lib/omnitrace/library/common.hpp
+++ b/source/lib/omnitrace/library/common.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "common/join.hpp"
 #include "library/defines.hpp"
 
 #include <timemory/api.hpp>
@@ -49,3 +50,8 @@ namespace omnitrace
 {
 namespace api = tim::api;  // NOLINT
 }
+
+// same sort of functionality as python's " ".join([...])
+#if !defined(JOIN)
+#    define JOIN(...) ::omnitrace::common::join(__VA_ARGS__)
+#endif

--- a/source/lib/omnitrace/library/defines.hpp.in
+++ b/source/lib/omnitrace/library/defines.hpp.in
@@ -57,31 +57,4 @@
 #define OMNITRACE_SAMPLING_GPU_BUSY         OMNITRACE_SAMPLING_GPU_BUSY_idx
 #define OMNITRACE_SAMPLING_GPU_MEMORY_USAGE OMNITRACE_SAMPLING_GPU_MEMORY_USAGE_idx
 
-#define OMNITRACE_ATTRIBUTE(...)    __attribute__((__VA_ARGS__))
-#define OMNITRACE_VISIBILITY(MODE)  OMNITRACE_ATTRIBUTE(visibility(MODE))
-#define OMNITRACE_PUBLIC_API        OMNITRACE_VISIBILITY("default")
-#define OMNITRACE_HIDDEN_API        OMNITRACE_VISIBILITY("hidden")
-#define OMNITRACE_INLINE            OMNITRACE_ATTRIBUTE(always_inline) inline
-#define OMNITRACE_NOINLINE          OMNITRACE_ATTRIBUTE(noinline)
-#define OMNITRACE_HOT               OMNITRACE_ATTRIBUTE(hot)
-#define OMNITRACE_CONST             OMNITRACE_ATTRIBUTE(const)
-#define OMNITRACE_PURE              OMNITRACE_ATTRIBUTE(pure)
-#define OMNITRACE_PACKED            OMNITRACE_ATTRIBUTE(__packed__)
-#define OMNITRACE_PACKED_ALIGN(VAL) OMNITRACE_PACKED OMNITRACE_ATTRIBUTE(__aligned__(VAL))
-
-#if defined(OMNITRACE_CI) && OMNITRACE_CI > 0
-#    if defined(NDEBUG)
-#        undef NDEBUG
-#    endif
-#    if !defined(DEBUG)
-#        define DEBUG 1
-#    endif
-#    include <cassert>
-#endif
-
-#define OMNITRACE_STRINGIZE(X)           OMNITRACE_STRINGIZE2(X)
-#define OMNITRACE_STRINGIZE2(X)          #X
-#define OMNITRACE_VAR_NAME_COMBINE(X, Y) X##Y
-#define OMNITRACE_VARIABLE(Y)            OMNITRACE_VAR_NAME_COMBINE(_omni_var_, Y)
-#define OMNITRACE_LINESTR                OMNITRACE_STRINGIZE(__LINE__)
-#define OMNITRACE_ESC(...)               __VA_ARGS__
+#include "common/defines.h"

--- a/source/lib/omnitrace/library/mproc.cpp
+++ b/source/lib/omnitrace/library/mproc.cpp
@@ -21,8 +21,8 @@
 // SOFTWARE.
 
 #include "library/mproc.hpp"
+#include "library/common.hpp"
 #include "library/debug.hpp"
-#include "library/timemory.hpp"
 
 #include <fstream>
 #include <set>

--- a/source/lib/omnitrace/library/timemory.hpp
+++ b/source/lib/omnitrace/library/timemory.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "library/common.hpp"
 #include "library/components/fwd.hpp"
 #include "library/defines.hpp"
 
@@ -52,9 +53,6 @@ namespace dmp       = tim::dmp;        // NOLINT
 namespace process   = tim::process;    // NOLINT
 namespace units     = tim::units;      // NOLINT
 namespace trait     = tim::trait;      // NOLINT
-
-// same sort of functionality as python's " ".join([...])
-#if !defined(JOIN)
-#    define JOIN(...) tim::mpl::apply<std::string>::join(__VA_ARGS__)
-#endif
+namespace api       = tim::api;        // NOLINT
+namespace operation = tim::operation;  // NOLINT
 }  // namespace omnitrace


### PR DESCRIPTION
- `JOIN(...)` uses `::omnitrace::common::join` instead of `::tim::mpl::apply<>::join`
- move several pp defs from `library/defines.hpp.in` to `common/defines.h`
