### PR TITLE
Improved sampling performance

### DIFF
--- a/source/lib/omnitrace/library/components/backtrace.cpp
+++ b/source/lib/omnitrace/library/components/backtrace.cpp
@@ -331,7 +331,7 @@ backtrace::configure(bool _setup, int64_t _tid)
             if(get_papi_vector(_tid)) get_papi_vector(_tid)->start();
         }
 
-        auto _alrm_freq = 1.0 / get_sampling_freq();
+        auto _alrm_freq = 1.0 / std::min<double>(get_sampling_freq(), 20.0);
         auto _prof_freq = 1.0 / get_sampling_freq();
         auto _delay     = std::max<double>(1.0e-3, get_sampling_delay());
 

--- a/source/lib/omnitrace/library/components/backtrace.hpp
+++ b/source/lib/omnitrace/library/components/backtrace.hpp
@@ -81,14 +81,14 @@ struct backtrace
     static void               post_process(int64_t _tid = threading::get_id());
     static hw_counter_data_t& get_last_hwcounters();
 
-    static void              start();
-    static void              stop();
-    void                     sample(int = -1);
-    bool                     empty() const;
-    size_t                   size() const;
-    std::vector<std::string> get() const;
-    uint64_t                 get_timestamp() const;
-    int64_t                  get_thread_cpu_timestamp() const;
+    static void                   start();
+    static void                   stop();
+    void                          sample(int = -1);
+    bool                          empty() const;
+    size_t                        size() const;
+    std::vector<std::string_view> get() const;
+    uint64_t                      get_timestamp() const;
+    int64_t                       get_thread_cpu_timestamp() const;
 
 private:
     int64_t           m_tid        = 0;

--- a/source/lib/omnitrace/library/perfetto.hpp
+++ b/source/lib/omnitrace/library/perfetto.hpp
@@ -31,6 +31,7 @@
 #define OMNITRACE_PERFETTO_CATEGORIES                                                    \
     perfetto::Category("host").SetDescription("Host-side function tracing"),             \
         perfetto::Category("user").SetDescription("User-defined regions"),               \
+        perfetto::Category("sampling").SetDescription("Host-side function sampling"),    \
         perfetto::Category("device_hip")                                                 \
             .SetDescription("Device-side functions submitted via HSA API"),              \
         perfetto::Category("device_hsa")                                                 \


### PR DESCRIPTION
- decreases the time required to sample
- fixes some filtering in the perfetto/timemory output
- backtrace::get() returns vector of string_view
- wrapped samples in perfetto "samples [omnitrace]" block
- samples in TID=0 in sampling mode are in separate thread row