### PR TITLE
Adds test which validates errors for missing configs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -462,16 +462,8 @@ add_test(
 set_tests_properties(
     omnitrace-invalid-config
     PROPERTIES ENVIRONMENT
-               "OMNITRACE_CONFIG_FILE=${CMAKE_CURRENT_BINARY_DIR}/invalid.cfg"
-               TIMEOUT
-               120
-               LABELS
-               "config"
-               WILL_FAIL
-               ON
-               PASS_REGULAR_EXPRESSION
-               "Error reading configuration file: ${CMAKE_CURRENT_BINARY_DIR}/invalid.cfg"
-    )
+               "OMNITRACE_CONFIG_FILE=${CMAKE_CURRENT_BINARY_DIR}/invalid.cfg" TIMEOUT
+               120 LABELS "config" WILL_FAIL ON)
 
 add_test(
     NAME omnitrace-missing-config
@@ -481,16 +473,8 @@ add_test(
 set_tests_properties(
     omnitrace-missing-config
     PROPERTIES ENVIRONMENT
-               "OMNITRACE_CONFIG_FILE=${CMAKE_CURRENT_BINARY_DIR}/missing.cfg"
-               TIMEOUT
-               120
-               LABELS
-               "config"
-               WILL_FAIL
-               ON
-               PASS_REGULAR_EXPRESSION
-               "Error reading configuration file: ${CMAKE_CURRENT_BINARY_DIR}/missing.cfg"
-    )
+               "OMNITRACE_CONFIG_FILE=${CMAKE_CURRENT_BINARY_DIR}/missing.cfg" TIMEOUT
+               120 LABELS "config" WILL_FAIL ON)
 
 # -------------------------------------------------------------------------------------- #
 #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -438,6 +438,65 @@ function(OMNITRACE_ADD_PYTHON_TEST)
 endfunction()
 
 # -------------------------------------------------------------------------------------- #
+#
+# general config file tests
+#
+# -------------------------------------------------------------------------------------- #
+file(
+    WRITE ${CMAKE_CURRENT_BINARY_DIR}/invalid.cfg
+    "
+FOOBAR = ON
+")
+
+if(TARGET parallel-overhead)
+    set(_CONFIG_TEST_EXE $<TARGET_FILE:parallel-overhead>)
+else()
+    set(_CONFIG_TEST_EXE ls)
+endif()
+
+add_test(
+    NAME omnitrace-invalid-config
+    COMMAND $<TARGET_FILE:omnitrace-exe> -- ${_CONFIG_TEST_EXE}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+set_tests_properties(
+    omnitrace-invalid-config
+    PROPERTIES ENVIRONMENT
+               "OMNITRACE_CONFIG_FILE=${CMAKE_CURRENT_BINARY_DIR}/invalid.cfg"
+               TIMEOUT
+               120
+               LABELS
+               "config"
+               WILL_FAIL
+               ON
+               PASS_REGULAR_EXPRESSION
+               "Error reading configuration file: ${CMAKE_CURRENT_BINARY_DIR}/invalid.cfg"
+    )
+
+add_test(
+    NAME omnitrace-missing-config
+    COMMAND $<TARGET_FILE:omnitrace-exe> -- ${_CONFIG_TEST_EXE}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+
+set_tests_properties(
+    omnitrace-missing-config
+    PROPERTIES ENVIRONMENT
+               "OMNITRACE_CONFIG_FILE=${CMAKE_CURRENT_BINARY_DIR}/missing.cfg"
+               TIMEOUT
+               120
+               LABELS
+               "config"
+               WILL_FAIL
+               ON
+               PASS_REGULAR_EXPRESSION
+               "Error reading configuration file: ${CMAKE_CURRENT_BINARY_DIR}/missing.cfg"
+    )
+
+# -------------------------------------------------------------------------------------- #
+#
+# binary-rewrite and runtime-instrumentation tests
+#
+# -------------------------------------------------------------------------------------- #
 
 omnitrace_add_test(
     NAME transpose


### PR DESCRIPTION
- updates timemory submodule with fix for protection against recursion
  - within `settings::read(...)` of timemory, there was a bug in the implementation protecting recursively reading the same config files
  - bug introduced in #69 