### PR TITLE
Handle OMNITRACE_ENABLED + minor updates

### DIFF
--- a/source/lib/omnitrace/library/components/pthread_create_gotcha.hpp
+++ b/source/lib/omnitrace/library/components/pthread_create_gotcha.hpp
@@ -34,9 +34,11 @@ namespace omnitrace
 {
 struct pthread_create_gotcha : tim::component::base<pthread_create_gotcha, void>
 {
+    using routine_t = void* (*) (void*);
+    using wrappee_t = int (*)(pthread_t*, const pthread_attr_t*, routine_t, void*);
+
     struct wrapper
     {
-        using routine_t = void* (*) (void*);
         using promise_t = std::promise<void>;
 
         wrapper(routine_t _routine, void* _arg, bool, int64_t, promise_t*);
@@ -68,6 +70,11 @@ struct pthread_create_gotcha : tim::component::base<pthread_create_gotcha, void>
 
     static auto& get_execution_time(int64_t _tid = threading::get_id());
     static bool  is_valid_execution_time(int64_t _tid, uint64_t _ts);
+
+    void set_data(wrappee_t);
+
+private:
+    wrappee_t m_wrappee = &pthread_create;
 };
 
 inline auto&

--- a/source/lib/omnitrace/library/components/roctracer.cpp
+++ b/source/lib/omnitrace/library/components/roctracer.cpp
@@ -166,7 +166,12 @@ void
 roctracer::shutdown()
 {
     auto_lock_t _lk{ type_mutex<roctracer>() };
-    if(!roctracer_is_setup()) return;
+    if(!roctracer_is_setup())
+    {
+        if(!roctracer_is_init() && tim::storage<comp::roctracer_data>::instance())
+            tim::storage<comp::roctracer_data>::instance()->reset();
+        return;
+    }
     roctracer_is_setup() = false;
 
     OMNITRACE_VERBOSE_F(1, "shutting down roctracer...\n");

--- a/source/lib/omnitrace/library/components/roctracer_callbacks.cpp
+++ b/source/lib/omnitrace/library/components/roctracer_callbacks.cpp
@@ -854,6 +854,13 @@ hip_activity_callback(const char* begin, const char* end, void*)
 }
 
 bool&
+roctracer_is_init()
+{
+    static bool _v = tim::get_env("OMNITRACE_ROCTRACER_IS_INIT", false);
+    return _v;
+}
+
+bool&
 roctracer_is_setup()
 {
     static bool _v = false;
@@ -892,7 +899,9 @@ extern "C"
                 const char* const* failed_tool_names)
     {
         if(!tim::get_env("OMNITRACE_INIT_TOOLING", true)) return true;
+        if(!tim::settings::enabled()) return true;
 
+        roctracer_is_init() = true;
         pthread_gotcha::push_enable_sampling_on_child_threads(false);
         OMNITRACE_CONDITIONAL_BASIC_PRINT_F(get_debug_env() || get_verbose_env() > 0,
                                             "\n");

--- a/source/lib/omnitrace/library/components/roctracer_callbacks.hpp
+++ b/source/lib/omnitrace/library/components/roctracer_callbacks.hpp
@@ -72,6 +72,9 @@ void
 hip_activity_callback(const char* begin, const char* end, void*);
 
 bool&
+roctracer_is_init();
+
+bool&
 roctracer_is_setup();
 
 roctracer_functions_t&

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -604,6 +604,22 @@ configure_mode_settings()
     // recycle all subsequent thread ids
     threading::recycle_ids() =
         tim::get_env<bool>("OMNITRACE_RECYCLE_TIDS", !get_use_sampling());
+
+    if(!get_config()->get_enabled())
+    {
+        _set("OMNITRACE_USE_PERFETTO", false);
+        _set("OMNITRACE_USE_TIMEMORY", false);
+        _set("OMNITRACE_USE_ROCM_SMI", false);
+        _set("OMNITRACE_USE_ROCTRACER", false);
+        _set("OMNITRACE_USE_KOKKOSP", false);
+        _set("OMNITRACE_USE_OMPT", false);
+        _set("OMNITRACE_USE_SAMPLING", false);
+        _set("OMNITRACE_USE_PROCESS_SAMPLING", false);
+        _set("OMNITRACE_USE_CODE_COVERAGE", false);
+        _set("OMNITRACE_CRITICAL_TRACE", false);
+        set_setting_value("OMNITRACE_TIMEMORY_COMPONENTS", std::string{});
+        set_setting_value("OMNITRACE_PAPI_EVENTS", std::string{});
+    }
 }
 
 void

--- a/source/lib/omnitrace/library/ompt.cpp
+++ b/source/lib/omnitrace/library/ompt.cpp
@@ -61,6 +61,7 @@ bool _init_toolset_off = (trait::runtime_enabled<ompt_toolset_t>::set(false),
 void
 setup()
 {
+    if(!tim::settings::enabled()) return;
     trait::runtime_enabled<ompt_toolset_t>::set(true);
     trait::runtime_enabled<ompt_context_t>::set(true);
     comp::user_ompt_bundle::global_init();


### PR DESCRIPTION
- handle OMNITRACE_ENABLED=OFF by disabling everything
- use set_data to get callback in pthread_create_gotcha
- clear roctracer_data storage if roctracer not initialized