### PR TITLE
Fix statistics type and use feature name indexes

### DIFF
--- a/source/lib/omnitrace/library/components/rocprofiler.cpp
+++ b/source/lib/omnitrace/library/components/rocprofiler.cpp
@@ -45,9 +45,6 @@
 #include <string_view>
 #include <type_traits>
 
-TIMEMORY_STATISTICS_TYPE(component::rocm_data_tracker, component::rocm_feature_value)
-TIMEMORY_DEFINE_CONCRETE_TRAIT(report_units, component::rocm_data_tracker, false_type)
-
 namespace tim
 {
 namespace component
@@ -86,7 +83,7 @@ rocm_event::rocm_event(uint32_t _dev, uint32_t _thr, uint32_t _queue,
     for(uint32_t i = 0; i < _feature_count; ++i)
     {
         const rocprofiler_feature_t* p = &_features[i];
-        feature_names.emplace_back(p->name);
+        feature_names.emplace_back(i);
         switch(p->data.kind)
         {
             // Output metrics results
@@ -121,7 +118,9 @@ rocm_event::as_string() const
     _ss << std::fixed;
     for(size_t i = 0; i < feature_names.size(); ++i)
     {
-        _ss << ", " << feature_names.at(i) << " = ";
+        auto _name = omnitrace::rocprofiler::get_data_labels().at(device_id).at(
+            feature_names.at(i));
+        _ss << ", " << _name << " = ";
         auto _as_string = [&_ss](auto&& itr) { _ss << std::setw(4) << itr; };
         std::visit(_as_string, feature_values.at(i));
     }

--- a/source/lib/omnitrace/library/components/rocprofiler.hpp
+++ b/source/lib/omnitrace/library/components/rocprofiler.hpp
@@ -82,7 +82,7 @@ struct rocm_event
     rocm_metric_type                entry          = 0;
     rocm_metric_type                exit           = 0;
     std::string                     name           = {};
-    std::vector<std::string_view>   feature_names  = {};
+    std::vector<size_t>             feature_names  = {};
     std::vector<rocm_feature_value> feature_values = {};
 
     rocm_event() = default;
@@ -224,6 +224,8 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_timing_category, component::rocprofiler_data,
 TIMEMORY_DEFINE_CONCRETE_TRAIT(uses_timing_units, component::rocprofiler_data, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(report_units, component::rocprofiler_data, false_type)
 TIMEMORY_STATISTICS_TYPE(component::rocprofiler_data, component::rocprofiler_value)
+TIMEMORY_STATISTICS_TYPE(component::rocm_data_tracker, component::rocm_feature_value)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(report_units, component::rocm_data_tracker, false_type)
 
 #if !defined(OMNITRACE_EXTERN_COMPONENTS) ||                                             \
     (defined(OMNITRACE_EXTERN_COMPONENTS) && OMNITRACE_EXTERN_COMPONENTS > 0)

--- a/source/lib/omnitrace/library/rocprofiler.cpp
+++ b/source/lib/omnitrace/library/rocprofiler.cpp
@@ -533,7 +533,10 @@ post_process_perfetto()
                     return JOIN(" ", "Device", _v, JOIN("", '[', _dev_id, ']'));
                 };
                 for(auto nitr : itr.feature_names)
-                    counter_track::emplace(_dev_id, addendum(nitr));
+                {
+                    auto _name = get_data_labels().at(itr.device_id).at(nitr);
+                    counter_track::emplace(_dev_id, addendum(_name));
+                }
             }
         }
 
@@ -737,7 +740,9 @@ post_process_timemory()
             {
                 _storage.reserve(_n);
                 for(size_t i = _storage.size(); i < _n; ++i)
-                    _storage.emplace_back(ditr.first, i, itr->feature_names.at(i));
+                    _storage.emplace_back(
+                        ditr.first, i,
+                        get_data_labels().at(ditr.first).at(itr->feature_names.at(i)));
             }
         }
 

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -94,7 +94,8 @@ thread_init()
         if(threading::get_id() > 0)
             threading::set_thread_name(JOIN(" ", "Thread", threading::get_id()).c_str());
         thread_data<omnitrace_thread_bundle_t>::construct(
-            JOIN('/', "omnitrace", process::get_id(), "thread", threading::get_id()),
+            JOIN('/', "omnitrace/process", process::get_id(), "thread",
+                 threading::get_id()),
             quirk::config<quirk::auto_start>{});
         get_interval_data()->reserve(512);
         // save the hash maps


### PR DESCRIPTION
- fix reporting units and statistics type for rocm_data_tracker
- use indexes for feature names instead of strings