### PR TITLE
Support ACTIVITY_DOMAIN_ROCTX

### DIFF
--- a/source/lib/omnitrace/library/components/fwd.hpp
+++ b/source/lib/omnitrace/library/components/fwd.hpp
@@ -69,6 +69,7 @@ TIMEMORY_DEFINE_NS_API(category, device_hsa)
 TIMEMORY_DEFINE_NS_API(category, rocm_hip)
 TIMEMORY_DEFINE_NS_API(category, rocm_hsa)
 TIMEMORY_DEFINE_NS_API(category, rocm_smi)
+TIMEMORY_DEFINE_NS_API(category, rocm_roctx)
 TIMEMORY_DEFINE_NS_API(category, kokkos)
 TIMEMORY_DEFINE_NS_API(category, mpi)
 TIMEMORY_DEFINE_NS_API(category, ompt)
@@ -84,6 +85,7 @@ TIMEMORY_DEFINE_NAME_TRAIT("user", category::user);
 TIMEMORY_DEFINE_NAME_TRAIT("rocm_hip", category::rocm_hip);
 TIMEMORY_DEFINE_NAME_TRAIT("rocm_hsa", category::rocm_hsa);
 TIMEMORY_DEFINE_NAME_TRAIT("rocm_smi", category::rocm_smi);
+TIMEMORY_DEFINE_NAME_TRAIT("rocm_roctx", category::rocm_roctx);
 TIMEMORY_DEFINE_NAME_TRAIT("sampling", category::sampling);
 TIMEMORY_DEFINE_NAME_TRAIT("thread_sampling", category::thread_sampling);
 TIMEMORY_DEFINE_NAME_TRAIT("kokkos", category::kokkos);

--- a/source/lib/omnitrace/library/components/roctracer.cpp
+++ b/source/lib/omnitrace/library/components/roctracer.cpp
@@ -150,8 +150,11 @@ roctracer::setup()
 
     ROCTRACER_CALL(roctracer_enable_domain_callback(ACTIVITY_DOMAIN_HIP_API,
                                                     hip_api_callback, nullptr));
-    // ROCTRACER_CALL(roctracer_enable_domain_callback(ACTIVITY_DOMAIN_ROCTX,
-    //                                                hip_api_callback, nullptr));
+    if(get_use_roctx())
+    {
+        ROCTRACER_CALL(roctracer_enable_domain_callback(ACTIVITY_DOMAIN_ROCTX,
+                                                        roctx_api_callback, nullptr));
+    }
     // Enable HIP activity tracing
     ROCTRACER_CALL(roctracer_enable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS));
 

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -228,6 +228,11 @@ configure_settings(bool _init)
         "Enable sampling GPU power, temp, utilization, and memory usage", true, "backend",
         "rocm_smi", "rocm");
 
+    OMNITRACE_CONFIG_SETTING(
+        bool, "OMNITRACE_USE_ROCTX",
+        "Enable ROCtx API. Warning! Out-of-order ranges may corrupt perfetto flamegraph",
+        false, "backend", "roctracer", "rocm", "roctx");
+
     OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_USE_SAMPLING",
                              "Enable statistical sampling of call-stack", false,
                              "backend", "sampling");
@@ -1192,6 +1197,17 @@ get_use_rocm_smi()
 {
 #if defined(OMNITRACE_USE_ROCM_SMI) && OMNITRACE_USE_ROCM_SMI > 0
     static auto _v = get_config()->find("OMNITRACE_USE_ROCM_SMI");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+#else
+    return false;
+#endif
+}
+
+bool
+get_use_roctx()
+{
+#if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0
+    static auto _v = get_config()->find("OMNITRACE_USE_ROCTX");
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 #else
     return false;

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -174,6 +174,9 @@ get_use_rocprofiler() OMNITRACE_HOT;
 bool
 get_use_rocm_smi() OMNITRACE_HOT;
 
+bool
+get_use_roctx();
+
 bool&
 get_use_sampling() OMNITRACE_HOT;
 

--- a/source/lib/omnitrace/library/perfetto.hpp
+++ b/source/lib/omnitrace/library/perfetto.hpp
@@ -38,6 +38,7 @@
             .SetDescription("Device-side functions submitted via HIP API"),              \
         perfetto::Category("rocm_hip").SetDescription("Host-side HIP functions"),        \
         perfetto::Category("rocm_hsa").SetDescription("Host-side HSA functions"),        \
+        perfetto::Category("rocm_roctx").SetDescription("Host-side ROCTX labels"),       \
         perfetto::Category("device_busy")                                                \
             .SetDescription("Busy percentage of a GPU device"),                          \
         perfetto::Category("device_temp")                                                \

--- a/source/lib/omnitrace/library/roctracer.hpp
+++ b/source/lib/omnitrace/library/roctracer.hpp
@@ -67,6 +67,9 @@ hip_exec_activity_callbacks(int64_t _tid);
 void
 hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
 
+void
+roctx_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
+
 // Activity tracing callback
 void
 hip_activity_callback(const char* begin, const char* end, void*);


### PR DESCRIPTION
- New configuration variable: `OMNITRACE_USE_ROCTX`
- Enable support for roctxRangePushA, roctxRangePop, roctxRangeStartA, roctxRangeStop