### PR TITLE
Fixes missing call to mpi_gotcha::update()

### DIFF
--- a/source/lib/omnitrace/library.cpp
+++ b/source/lib/omnitrace/library.cpp
@@ -846,15 +846,16 @@ omnitrace_finalize_hidden(void)
         sampling::block_signals();
     }
 
-    OMNITRACE_VERBOSE_F(1, "Shutting down miscellaneous gotchas...\n");
     // stop the gotcha bundle
     if(get_gotcha_bundle())
     {
+        OMNITRACE_VERBOSE_F(1, "Shutting down miscellaneous gotchas...\n");
         get_gotcha_bundle()->stop();
         get_gotcha_bundle().reset();
+        mpi_gotcha::shutdown();
     }
 
-    OMNITRACE_VERBOSE_F(1, "Shutting down pthread gotcha...\n");
+    OMNITRACE_VERBOSE_F(1, "Shutting down pthread gotchas...\n");
     pthread_gotcha::shutdown();
 
     if(get_use_process_sampling())
@@ -1024,7 +1025,8 @@ omnitrace_finalize_hidden(void)
                 return _dst;
             };
 
-            perfetto_mpi_get_t{ _rank_data, _trace_data, _combine };
+            perfetto_mpi_get_t{ get_perfetto_combined_traces(), settings::node_count() }(
+                _rank_data, _trace_data, _combine);
             for(auto& itr : _rank_data)
                 trace_data =
                     (trace_data.empty()) ? std::move(itr) : _combine(trace_data, itr);

--- a/source/lib/omnitrace/library/components/mpi_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/mpi_gotcha.cpp
@@ -137,6 +137,12 @@ mpi_gotcha::configure()
     };
 }
 
+void
+mpi_gotcha::shutdown()
+{
+    update();
+}
+
 bool
 mpi_gotcha::update()
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -605,18 +605,10 @@ omnitrace_add_test(
         args
         --min-instructions
         0
-    RUNTIME_ARGS
-        -e
-        -v
-        1
-        --label
-        file
-        line
-        return
-        args
-        --min-instructions
-        0
-    ENVIRONMENT "${_base_environment}")
+    ENVIRONMENT "${_base_environment}"
+    REWRITE_RUN_PASS_REGEX
+        "(/[A-Za-z-]+/perfetto-trace-0.proto).*(/[A-Za-z-]+/wall_clock-0.txt')"
+    REWRITE_RUN_FAIL_REGEX "-[0-9][0-9]+.(json|txt|proto)")
 
 omnitrace_add_test(
     NAME lulesh


### PR DESCRIPTION
- mpi_gotcha::shutdown() calls mpi_gotcha::update()
  - fixes the MPI rank not being available to output files when `OMNITRACE_USE_PID=ON` 