### PR TITLE
Sampling Tweaks: disable sampling itimer

### DIFF
--- a/source/lib/common/setup.hpp
+++ b/source/lib/common/setup.hpp
@@ -55,7 +55,7 @@ namespace omnitrace
 {
 inline namespace common
 {
-namespace utility
+namespace path
 {
 inline std::string
 find_path(const std::string& _path, int _verbose, std::string _search_paths = {})
@@ -109,15 +109,15 @@ dirname(const std::string& _fname)
         return _fname.substr(0, _fname.find_last_of('/'));
     return std::string{};
 }
-}  // namespace utility
+}  // namespace path
 
-void
+inline void
 setup_environ(int _verbose, const std::string& _search_paths = {},
               std::string _omnilib    = "libomnitrace.so",
               std::string _omnilib_dl = "libomnitrace-dl.so")
 {
-    _omnilib    = utility::find_path(_omnilib, _verbose, _search_paths);
-    _omnilib_dl = utility::find_path(_omnilib_dl, _verbose, _search_paths);
+    _omnilib    = common::path::find_path(_omnilib, _verbose, _search_paths);
+    _omnilib_dl = common::path::find_path(_omnilib_dl, _verbose, _search_paths);
 
     // This environment variable forces the ROCR-Runtime to use polling to wait
     // for signals rather than interrupts. We set this variable to avoid issues with
@@ -161,7 +161,8 @@ setup_environ(int _verbose, const std::string& _search_paths = {},
 #if defined(OMNITRACE_USE_OMPT) && OMNITRACE_USE_OMPT > 0
     std::string _omni_omp_libs = _omnilib_dl;
     const char* _omp_libs      = getenv("OMP_TOOL_LIBRARIES");
-    if(_omp_libs && std::string_view{ _omp_libs }.find(_omnilib_dl) == std::string::npos)
+    if(_omp_libs != nullptr &&
+       std::string_view{ _omp_libs }.find(_omnilib_dl) == std::string::npos)
         _omni_omp_libs = common::join(':', _omp_libs, _omnilib_dl);
     OMNITRACE_SETUP_LOG(_verbose >= 1, "setting OMP_TOOL_LIBRARIES to '%s'\n",
                         _omni_omp_libs.c_str());

--- a/source/lib/omnitrace-dl/dl.cpp
+++ b/source/lib/omnitrace-dl/dl.cpp
@@ -140,9 +140,9 @@ struct OMNITRACE_HIDDEN_API indirect
 {
     OMNITRACE_INLINE indirect(const std::string& _omnilib, const std::string& _userlib,
                               const std::string& _dllib)
-    : m_omnilib{ utility::find_path(_omnilib, _omnitrace_dl_verbose) }
-    , m_dllib{ utility::find_path(_dllib, _omnitrace_dl_verbose) }
-    , m_userlib{ utility::find_path(_userlib, _omnitrace_dl_verbose) }
+    : m_omnilib{ common::path::find_path(_omnilib, _omnitrace_dl_verbose) }
+    , m_dllib{ common::path::find_path(_dllib, _omnitrace_dl_verbose) }
+    , m_userlib{ common::path::find_path(_userlib, _omnitrace_dl_verbose) }
     {
         if(_omnitrace_dl_verbose >= 1)
         {
@@ -154,8 +154,8 @@ struct OMNITRACE_HIDDEN_API indirect
                     ::basename(_userlib.c_str()), m_userlib.c_str());
         }
 
-        auto _search_paths =
-            common::join(':', utility::dirname(_omnilib), utility::dirname(_dllib));
+        auto _search_paths = common::join(':', common::path::dirname(_omnilib),
+                                          common::path::dirname(_dllib));
         common::setup_environ(_omnitrace_dl_verbose, _search_paths, _omnilib, _dllib);
 
         m_omnihandle = open(m_omnilib);

--- a/source/lib/omnitrace/library.cpp
+++ b/source/lib/omnitrace/library.cpp
@@ -78,6 +78,8 @@ auto
 ensure_finalization(bool _static_init = false)
 {
     (void) threading::get_id();
+    (void) utility::get_thread_index();
+
     if(!_static_init)
     {
         OMNITRACE_DEBUG_F("\n");

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -29,6 +29,7 @@
 #include "library/runtime.hpp"
 #include "library/sampling.hpp"
 #include "library/timemory.hpp"
+#include "library/utility.hpp"
 
 namespace omnitrace
 {
@@ -121,9 +122,15 @@ inline void
 thread_init_sampling()
 {
     static thread_local auto _v = []() {
-        auto _use_sampling = get_use_sampling();
-        if(_use_sampling) sampling::setup();
-        return _use_sampling;
+        auto _idx = utility::get_thread_index();
+        // the main thread will initialize sampling when it initializes the tooling
+        if(_idx > 0)
+        {
+            auto _use_sampling = get_use_sampling();
+            if(_use_sampling) sampling::setup();
+            return _use_sampling;
+        }
+        return false;
     }();
     (void) _v;
 }


### PR DESCRIPTION
- tweaks starting sampling on main thread
  - rename omnitrace::common::utility to omnitrace::common::path
  - tracing::thread_init_sampling does not start sampling on main thread
- updates timemory submodule with support for cancelling itimer and SIGRTMIN through SIGRTMAX