### PR TITLE
Fix reliability when KOKKOS_PROFILE_LIBRARY is set in env

### DIFF
--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -58,6 +58,7 @@ jobs:
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
           -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
           -DOMNITRACE_CI_MPI_RUN_AS_ROOT=ON
+          -DOMNITRACE_MAX_THREADS=32
 
     - name: Build
       timeout-minutes: 60

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -88,6 +88,7 @@ jobs:
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
           -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
           -DLULESH_BUILD_KOKKOS=OFF
+          -DOMNITRACE_MAX_THREADS=32
 
     - name: Build
       timeout-minutes: 60

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -103,6 +103,7 @@ jobs:
           -DOMNITRACE_BUILD_STATIC_LIBSTDCXX=${{ matrix.static-libstdcxx }}
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
           -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_MAX_THREADS=32
 
     - name: Build
       timeout-minutes: 60
@@ -212,8 +213,8 @@ jobs:
         git config --global --add safe.directory ${PWD} &&
         cmake --version &&
         cmake -B build
-          -DCMAKE_C_COMPILER=${CC}
-          -DCMAKE_CXX_COMPILER=${CXX}
+          -DCMAKE_C_COMPILER=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g')
+          -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
           -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
           -DCMAKE_INSTALL_PREFIX=/opt/omnitrace
           -DOMNITRACE_BUILD_TESTING=OFF
@@ -223,7 +224,7 @@ jobs:
           -DOMNITRACE_USE_MPI=OFF
           -DOMNITRACE_USE_MPI_HEADERS=ON
           -DOMNITRACE_USE_HIP=ON
-          -DOMNITRACE_MAX_THREADS=64
+          -DOMNITRACE_MAX_THREADS=32
           -DOMNITRACE_USE_SANITIZER=OFF
           -DOMNITRACE_USE_PAPI=OFF
           -DOMNITRACE_INSTALL_PERFETTO_TOOLS=ON
@@ -367,6 +368,7 @@ jobs:
           -DDYNINST_BUILD_SHARED_LIBS=ON
           -DDYNINST_BUILD_STATIC_LIBS=OFF
           -DDYNINST_ELFUTILS_DOWNLOAD_VERSION=${{ env.ELFUTILS_DOWNLOAD_VERSION }}
+          -DOMNITRACE_MAX_THREADS=32
 
     - name: Build
       timeout-minutes: 60

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -688,11 +688,22 @@ configure_mode_settings()
 
     if(get_use_kokkosp())
     {
-        auto _force               = 0;
         auto _current_kokkosp_lib = tim::get_env<std::string>("KOKKOS_PROFILE_LIBRARY");
-        if(std::regex_search(_current_kokkosp_lib, std::regex{ "libtimemory\\." }))
-            _force = 1;
-        tim::set_env("KOKKOS_PROFILE_LIBRARY", "libomnitrace.so", _force);
+        if(_current_kokkosp_lib.find("libomnitrace-dl.so") == std::string::npos &&
+           _current_kokkosp_lib.find("libomnitrace.so") == std::string::npos)
+        {
+            auto        _force   = 0;
+            std::string _message = {};
+            if(std::regex_search(_current_kokkosp_lib, std::regex{ "libtimemory\\." }))
+            {
+                _force = 1;
+                _message =
+                    JOIN("", " (forced. Previous value: '", _current_kokkosp_lib, "')");
+            }
+            OMNITRACE_VERBOSE_F(1, "Setting KOKKOS_PROFILE_LIBRARY=%s%s\n",
+                                "libomnitrace.so", _message.c_str());
+            tim::set_env("KOKKOS_PROFILE_LIBRARY", "libomnitrace.so", _force);
+        }
     }
 
     // recycle all subsequent thread ids

--- a/source/lib/omnitrace/library/debug.hpp
+++ b/source/lib/omnitrace/library/debug.hpp
@@ -246,7 +246,7 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
 
 //--------------------------------------------------------------------------------------//
 
-#define OMNITRACE_CONDITIONAL_FAIL(COND, ...)                                            \
+#define OMNITRACE_CONDITIONAL_FAILURE(COND, METHOD, ...)                                 \
     if(COND)                                                                             \
     {                                                                                    \
         ::omnitrace::debug::flush();                                                     \
@@ -257,10 +257,10 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
         ::omnitrace::set_state(::omnitrace::State::Finalized);                           \
         ::tim::disable_signal_detection();                                               \
         ::tim::print_demangled_backtrace<64>();                                          \
-        ::std::exit(EXIT_FAILURE);                                                       \
+        METHOD;                                                                          \
     }
 
-#define OMNITRACE_CONDITIONAL_BASIC_FAIL(COND, ...)                                      \
+#define OMNITRACE_CONDITIONAL_BASIC_FAILURE(COND, METHOD, ...)                           \
     if(COND)                                                                             \
     {                                                                                    \
         ::omnitrace::debug::flush();                                                     \
@@ -270,10 +270,10 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
         ::omnitrace::set_state(::omnitrace::State::Finalized);                           \
         ::tim::disable_signal_detection();                                               \
         ::tim::print_demangled_backtrace<64>();                                          \
-        ::std::exit(EXIT_FAILURE);                                                       \
+        METHOD;                                                                          \
     }
 
-#define OMNITRACE_CONDITIONAL_FAIL_F(COND, ...)                                          \
+#define OMNITRACE_CONDITIONAL_FAILURE_F(COND, METHOD, ...)                               \
     if(COND)                                                                             \
     {                                                                                    \
         ::omnitrace::debug::flush();                                                     \
@@ -284,10 +284,10 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
         ::omnitrace::set_state(::omnitrace::State::Finalized);                           \
         ::tim::disable_signal_detection();                                               \
         ::tim::print_demangled_backtrace<64>();                                          \
-        ::std::exit(EXIT_FAILURE);                                                       \
+        METHOD;                                                                          \
     }
 
-#define OMNITRACE_CONDITIONAL_BASIC_FAIL_F(COND, ...)                                    \
+#define OMNITRACE_CONDITIONAL_BASIC_FAILURE_F(COND, METHOD, ...)                         \
     if(COND)                                                                             \
     {                                                                                    \
         ::omnitrace::debug::flush();                                                     \
@@ -297,24 +297,69 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
         ::omnitrace::set_state(::omnitrace::State::Finalized);                           \
         ::tim::disable_signal_detection();                                               \
         ::tim::print_demangled_backtrace<64>();                                          \
-        ::std::exit(EXIT_FAILURE);                                                       \
+        METHOD;                                                                          \
     }
 
-#define OMNITRACE_CI_FAIL(COND, ...)                                                     \
-    OMNITRACE_CONDITIONAL_FAIL(::omnitrace::get_is_continuous_integration() && (COND),   \
-                               __VA_ARGS__)
+#define OMNITRACE_CI_FAILURE(COND, METHOD, ...)                                          \
+    OMNITRACE_CONDITIONAL_FAILURE(                                                       \
+        ::omnitrace::get_is_continuous_integration() && (COND), METHOD, __VA_ARGS__)
 
-#define OMNITRACE_CI_BASIC_FAIL(COND, ...)                                               \
-    OMNITRACE_CONDITIONAL_BASIC_FAIL(                                                    \
-        ::omnitrace::get_is_continuous_integration() && (COND), __VA_ARGS__)
+#define OMNITRACE_CI_BASIC_FAILURE(COND, METHOD, ...)                                    \
+    OMNITRACE_CONDITIONAL_BASIC_FAILURE(                                                 \
+        ::omnitrace::get_is_continuous_integration() && (COND), METHOD, __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
+
+#define OMNITRACE_CONDITIONAL_FAIL(COND, ...)                                            \
+    OMNITRACE_CONDITIONAL_FAILURE(COND, OMNITRACE_ESC(::std::exit(EXIT_FAILURE)),        \
+                                  __VA_ARGS__)
+
+#define OMNITRACE_CONDITIONAL_BASIC_FAIL(COND, ...)                                      \
+    OMNITRACE_CONDITIONAL_BASIC_FAILURE(COND, OMNITRACE_ESC(::std::exit(EXIT_FAILURE)),  \
+                                        __VA_ARGS__)
+
+#define OMNITRACE_CONDITIONAL_FAIL_F(COND, ...)                                          \
+    OMNITRACE_CONDITIONAL_FAILURE_F(COND, OMNITRACE_ESC(::std::exit(EXIT_FAILURE)),      \
+                                    __VA_ARGS__)
+
+#define OMNITRACE_CONDITIONAL_BASIC_FAIL_F(COND, ...)                                    \
+    OMNITRACE_CONDITIONAL_BASIC_FAILURE_F(                                               \
+        COND, OMNITRACE_ESC(::std::exit(EXIT_FAILURE)), __VA_ARGS__)
+
+#define OMNITRACE_CI_FAIL(COND, ...)                                                     \
+    OMNITRACE_CI_FAILURE(COND, OMNITRACE_ESC(::std::exit(EXIT_FAILURE)), __VA_ARGS__)
+
+#define OMNITRACE_CI_BASIC_FAIL(COND, ...)                                               \
+    OMNITRACE_CI_BASIC_FAILURE(COND, OMNITRACE_ESC(::std::exit(EXIT_FAILURE)),           \
+                               __VA_ARGS__)
+
+//--------------------------------------------------------------------------------------//
+
+#define OMNITRACE_CONDITIONAL_ABORT(COND, ...)                                           \
+    OMNITRACE_CONDITIONAL_FAILURE(COND, OMNITRACE_ESC(::std::abort()), __VA_ARGS__)
+
+#define OMNITRACE_CONDITIONAL_BASIC_ABORT(COND, ...)                                     \
+    OMNITRACE_CONDITIONAL_BASIC_FAILURE(COND, OMNITRACE_ESC(::std::abort()), __VA_ARGS__)
+
+#define OMNITRACE_CONDITIONAL_ABORT_F(COND, ...)                                         \
+    OMNITRACE_CONDITIONAL_FAILURE_F(COND, OMNITRACE_ESC(::std::abort()), __VA_ARGS__)
+
+#define OMNITRACE_CONDITIONAL_BASIC_ABORT_F(COND, ...)                                   \
+    OMNITRACE_CONDITIONAL_BASIC_FAILURE_F(COND, OMNITRACE_ESC(::std::abort()),           \
+                                          __VA_ARGS__)
+
+#define OMNITRACE_CI_ABORT(COND, ...)                                                    \
+    OMNITRACE_CI_FAILURE(COND, OMNITRACE_ESC(::std::abort()), __VA_ARGS__)
+
+#define OMNITRACE_CI_BASIC_ABORT(COND, ...)                                              \
+    OMNITRACE_CI_BASIC_FAILURE(COND, OMNITRACE_ESC(::std::abort()), __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
 //
 //  Debug macros
 //
 //--------------------------------------------------------------------------------------//
+
 #define OMNITRACE_DEBUG(...)                                                             \
     OMNITRACE_CONDITIONAL_PRINT(::omnitrace::get_debug(), __VA_ARGS__)
 
@@ -338,6 +383,7 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
 //  Verbose macros
 //
 //--------------------------------------------------------------------------------------//
+
 #define OMNITRACE_VERBOSE(LEVEL, ...)                                                    \
     OMNITRACE_CONDITIONAL_PRINT(                                                         \
         ::omnitrace::get_debug() || (::omnitrace::get_verbose() >= LEVEL), __VA_ARGS__)
@@ -401,6 +447,21 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
 #define OMNITRACE_BASIC_FAIL(...) OMNITRACE_CONDITIONAL_BASIC_FAIL(true, __VA_ARGS__)
 
 #define OMNITRACE_BASIC_FAIL_F(...) OMNITRACE_CONDITIONAL_BASIC_FAIL_F(true, __VA_ARGS__)
+
+//--------------------------------------------------------------------------------------//
+//
+//  Abort macros
+//
+//--------------------------------------------------------------------------------------//
+
+#define OMNITRACE_ABORT(...) OMNITRACE_CONDITIONAL_ABORT(true, __VA_ARGS__)
+
+#define OMNITRACE_ABORT_F(...) OMNITRACE_CONDITIONAL_ABORT_F(true, __VA_ARGS__)
+
+#define OMNITRACE_BASIC_ABORT(...) OMNITRACE_CONDITIONAL_BASIC_ABORT(true, __VA_ARGS__)
+
+#define OMNITRACE_BASIC_ABORT_F(...)                                                     \
+    OMNITRACE_CONDITIONAL_BASIC_ABORT_F(true, __VA_ARGS__)
 
 #include <string>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,17 +23,15 @@ if(OMNITRACE_BUILD_DYNINST)
         )
 endif()
 
-set(_base_environment
-    "OMNITRACE_USE_PERFETTO=ON"
-    "OMNITRACE_USE_TIMEMORY=ON"
-    "OMNITRACE_USE_SAMPLING=ON"
-    "OMNITRACE_USE_PROCESS_SAMPLING=ON"
-    "OMNITRACE_TIME_OUTPUT=OFF"
-    "OMP_PROC_BIND=spread"
-    "OMP_PLACES=threads"
-    "OMP_NUM_THREADS=2"
+set(_test_library_path
     "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
     )
+set(_test_openmp_env "OMP_PROC_BIND=spread" "OMP_PLACES=threads" "OMP_NUM_THREADS=2")
+
+set(_base_environment
+    "OMNITRACE_USE_PERFETTO=ON" "OMNITRACE_USE_TIMEMORY=ON" "OMNITRACE_USE_SAMPLING=ON"
+    "OMNITRACE_USE_PROCESS_SAMPLING=ON" "OMNITRACE_TIME_OUTPUT=OFF" "${_test_openmp_env}"
+    "${_test_library_path}")
 
 set(_flat_environment
     "OMNITRACE_USE_PERFETTO=ON"
@@ -61,44 +59,22 @@ set(_lock_environment
     "OMNITRACE_TIME_OUTPUT=OFF"
     "OMNITRACE_FLAT_PROFILE=ON"
     "OMNITRACE_TIMELINE_PROFILE=OFF"
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
-    )
+    "${_test_library_path}")
 
 set(_ompt_environment
-    "OMNITRACE_USE_PERFETTO=ON"
-    "OMNITRACE_USE_TIMEMORY=ON"
-    "OMNITRACE_TIME_OUTPUT=OFF"
-    "OMNITRACE_USE_OMPT=ON"
-    "OMNITRACE_CRITICAL_TRACE=OFF"
-    "OMP_PROC_BIND=spread"
-    "OMP_PLACES=threads"
-    "OMP_NUM_THREADS=2"
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
-    )
+    "OMNITRACE_USE_PERFETTO=ON" "OMNITRACE_USE_TIMEMORY=ON" "OMNITRACE_TIME_OUTPUT=OFF"
+    "OMNITRACE_USE_OMPT=ON" "OMNITRACE_CRITICAL_TRACE=OFF" "${_test_openmp_env}"
+    "${_test_library_path}")
 
 set(_perfetto_environment
-    "OMNITRACE_USE_PERFETTO=ON"
-    "OMNITRACE_USE_TIMEMORY=OFF"
-    "OMNITRACE_USE_SAMPLING=ON"
-    "OMNITRACE_USE_PROCESS_SAMPLING=ON"
-    "OMNITRACE_TIME_OUTPUT=OFF"
-    "OMP_PROC_BIND=spread"
-    "OMP_PLACES=threads"
-    "OMP_NUM_THREADS=2"
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
-    )
+    "OMNITRACE_USE_PERFETTO=ON" "OMNITRACE_USE_TIMEMORY=OFF" "OMNITRACE_USE_SAMPLING=ON"
+    "OMNITRACE_USE_PROCESS_SAMPLING=ON" "OMNITRACE_TIME_OUTPUT=OFF" "${_test_openmp_env}"
+    "${_test_library_path}")
 
 set(_timemory_environment
-    "OMNITRACE_USE_PERFETTO=OFF"
-    "OMNITRACE_USE_TIMEMORY=ON"
-    "OMNITRACE_USE_SAMPLING=ON"
-    "OMNITRACE_USE_PROCESS_SAMPLING=ON"
-    "OMNITRACE_TIME_OUTPUT=OFF"
-    "OMP_PROC_BIND=spread"
-    "OMP_PLACES=threads"
-    "OMP_NUM_THREADS=2"
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
-    )
+    "OMNITRACE_USE_PERFETTO=OFF" "OMNITRACE_USE_TIMEMORY=ON" "OMNITRACE_USE_SAMPLING=ON"
+    "OMNITRACE_USE_PROCESS_SAMPLING=ON" "OMNITRACE_TIME_OUTPUT=OFF" "${_test_openmp_env}"
+    "${_test_library_path}")
 
 set(_test_environment ${_base_environment} "OMNITRACE_CRITICAL_TRACE=OFF")
 
@@ -111,7 +87,7 @@ set(_python_environment
     "OMNITRACE_TREE_OUTPUT=OFF"
     "OMNITRACE_USE_PID=OFF"
     "OMNITRACE_TIMEMORY_COMPONENTS=trip_count"
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
+    "${_test_library_path}"
     "PYTHONPATH=${PROJECT_BINARY_DIR}/lib/python/site-packages")
 
 set(_attach_environment
@@ -124,11 +100,8 @@ set(_attach_environment
     "OMNITRACE_USE_KOKKOSP=ON"
     "OMNITRACE_TIME_OUTPUT=OFF"
     "OMNITRACE_USE_PID=OFF"
-    "OMP_PROC_BIND=spread"
-    "OMP_PLACES=threads"
-    "OMP_NUM_THREADS=2"
-    "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${OMNITRACE_DYNINST_API_RT_DIR}:$ENV{LD_LIBRARY_PATH}"
-    )
+    "${_test_openmp_env}"
+    "${_test_library_path}")
 
 # -------------------------------------------------------------------------------------- #
 
@@ -690,9 +663,34 @@ omnitrace_add_test(
         args
         -ME
         [==[lib(gomp|m-)]==]
+    LABELS "kokkos;kokkos-profile-library"
+    RUN_ARGS -i 10 -s 20 -p
+    ENVIRONMENT
+        "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=ON;KOKKOS_PROFILE_LIBRARY=libomnitrace-dl.so"
+    )
+
+omnitrace_add_test(
+    SKIP_RUNTIME SKIP_REWRITE
+    NAME lulesh-baseline-kokkosp-libomnitrace
+    TARGET lulesh
+    MPI ${LULESH_USE_MPI}
+    NUM_PROCS 8
+    LABELS "kokkos;kokkos-profile-library"
     RUN_ARGS -i 10 -s 20 -p
     ENVIRONMENT
         "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=ON;KOKKOS_PROFILE_LIBRARY=libomnitrace.so"
+    )
+
+omnitrace_add_test(
+    SKIP_RUNTIME SKIP_REWRITE
+    NAME lulesh-baseline-kokkosp-libomnitrace-dl
+    TARGET lulesh
+    MPI ${LULESH_USE_MPI}
+    NUM_PROCS 8
+    LABELS "kokkos;kokkos-profile-library"
+    RUN_ARGS -i 10 -s 20 -p
+    ENVIRONMENT
+        "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=ON;KOKKOS_PROFILE_LIBRARY=libomnitrace-dl.so"
     )
 
 omnitrace_add_test(


### PR DESCRIPTION
- in certain situations, an exe using kokkos may be instrumented
- this will cause libomnitrace to be dlopened via libomnitrace-dl
- if KOKKOS_PROFILE_LIBRARY is set to libomnitrace and not libomnitrace-dl, you will end up with different instances of libomnitrace trying to collect data
- new OMNITRACE_ABORT macros
- simplifies the definition of test environments
- Adds new tests for KokkosP