### PR TITLE
Sampling use SIGRTMIN + N signals

### DIFF
--- a/source/bin/tests/CMakeLists.txt
+++ b/source/bin/tests/CMakeLists.txt
@@ -252,6 +252,7 @@ omnitrace_add_bin_test(
          -r
          _P
          ~PERFETTO
+         ~PROCESS_SAMPLING
          --csv
          --brief
     LABELS "omnitrace-avail"

--- a/source/lib/omnitrace/library/components/backtrace.hpp
+++ b/source/lib/omnitrace/library/components/backtrace.hpp
@@ -33,7 +33,6 @@
 #include <timemory/components/papi/types.hpp>
 #include <timemory/macros/language.hpp>
 #include <timemory/mpl/concepts.hpp>
-#include <timemory/sampling/sampler.hpp>
 #include <timemory/variadic/types.hpp>
 
 #include <array>

--- a/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
@@ -295,8 +295,8 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
 
     // block the signals in entire process
     OMNITRACE_DEBUG("blocking signals...\n");
-    tim::sampling::block_signals({ SIGRTMIN, SIGPROF },
-                                 tim::sampling::sigmask_scope::process);
+    auto _blocked_signals = get_sampling_signals();
+    tim::sampling::block_signals(_blocked_signals, tim::sampling::sigmask_scope::process);
 
     start_bundle(_bundle);
 
@@ -316,7 +316,7 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
 
     // unblock the signals in the entire process
     OMNITRACE_DEBUG("unblocking signals...\n");
-    tim::sampling::unblock_signals({ SIGRTMIN, SIGPROF },
+    tim::sampling::unblock_signals(_blocked_signals,
                                    tim::sampling::sigmask_scope::process);
 
     OMNITRACE_DEBUG("returning success...\n");

--- a/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
@@ -295,7 +295,7 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
 
     // block the signals in entire process
     OMNITRACE_DEBUG("blocking signals...\n");
-    tim::sampling::block_signals({ SIGALRM, SIGPROF },
+    tim::sampling::block_signals({ SIGRTMIN, SIGPROF },
                                  tim::sampling::sigmask_scope::process);
 
     start_bundle(_bundle);
@@ -316,7 +316,7 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
 
     // unblock the signals in the entire process
     OMNITRACE_DEBUG("unblocking signals...\n");
-    tim::sampling::unblock_signals({ SIGALRM, SIGPROF },
+    tim::sampling::unblock_signals({ SIGRTMIN, SIGPROF },
                                    tim::sampling::sigmask_scope::process);
 
     OMNITRACE_DEBUG("returning success...\n");

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -694,7 +694,7 @@ configure_signal_handler()
         using sys_signal      = tim::sys_signal;
         tim::disable_signal_detection();
         auto _exit_action = [](int nsig) {
-            tim::sampling::block_signals({ SIGPROF, SIGALRM },
+            tim::sampling::block_signals({ SIGPROF, SIGRTMIN },
                                          tim::sampling::sigmask_scope::process);
             OMNITRACE_BASIC_PRINT(
                 "Finalizing afer signal %i :: %s\n", nsig,

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -25,6 +25,7 @@
 #include "library/defines.hpp"
 #include "library/gpu.hpp"
 #include "library/perfetto.hpp"
+#include "library/runtime.hpp"
 
 #include <timemory/backends/dmp.hpp>
 #include <timemory/backends/mpi.hpp>
@@ -40,10 +41,12 @@
 #include <timemory/utility/declaration.hpp>
 #include <timemory/utility/signals.hpp>
 
+#include <algorithm>
 #include <array>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
+#include <limits>
 #include <numeric>
 #include <ostream>
 #include <string>
@@ -291,9 +294,15 @@ configure_settings(bool _init)
 
     OMNITRACE_CONFIG_SETTING(
         double, "OMNITRACE_SAMPLING_DELAY",
-        "Number of seconds to wait before the first sampling signal is delivered, "
+        "Time (in seconds) to wait before the first sampling signal is delivered, "
         "increasing this value can fix deadlocks during init",
         0.5, "sampling", "process_sampling");
+
+    OMNITRACE_CONFIG_SETTING(
+        double, "OMNITRACE_PROCESS_SAMPLING_FREQ",
+        "Number of measurements per second when OMNITTRACE_USE_PROCESS_SAMPLING=ON. If "
+        "set to zero, uses OMNITRACE_SAMPLING_FREQ value",
+        0.0, "process_sampling");
 
     OMNITRACE_CONFIG_SETTING(
         std::string, "OMNITRACE_SAMPLING_CPUS",
@@ -340,6 +349,35 @@ configure_settings(bool _init)
                              "Enable tracing calls to pthread_rwlock_* functions. May "
                              "cause deadlocks with ROCm-enabled OpenMPI.",
                              false, "backend", "parallelism", "gotcha");
+
+    OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_SAMPLING_KEEP_INTERNAL",
+                             "If disabled, omnitrace will attempt to filter out internal "
+                             "routines from the sampling call-stacks",
+                             true, "sampling", "data");
+
+    OMNITRACE_CONFIG_SETTING(
+        bool, "OMNITRACE_SAMPLING_REALTIME",
+        "Enable sampling frequency via a wall-clock timer on child threads. This may "
+        "result in typically idle child threads consuming an unnecessary large amount of "
+        "CPU time. The main thread always has this enabled.",
+        false, "sampling");
+
+    OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_SAMPLING_CPUTIME",
+                             "Enable sampling frequency via a timer that measures both "
+                             "CPU time used by the current process, "
+                             "and CPU time expended on behalf of the process by the "
+                             "system. This is recommended.",
+                             true, "timemory", "sampling");
+
+    auto _sigrt_range = SIGRTMAX - SIGRTMIN;
+
+    OMNITRACE_CONFIG_SETTING(
+        int, "OMNITRACE_SAMPLING_REALTIME_OFFSET",
+        std::string{
+            "Modify this value only if the target process is also using SIGRTMIN. E.g. "
+            "the signal used is SIGRTMIN + <THIS_VALUE>. Value must be <= " } +
+            std::to_string(_sigrt_range),
+        0, "sampling");
 
     OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_FLAT_SAMPLING",
                              "Ignore hierarchy in all statistical sampling entries",
@@ -443,6 +481,7 @@ configure_settings(bool _init)
     OMNITRACE_CONFIG_SETTING(std::string, "OMNITRACE_OUTPUT_FILE",
                              "[DEPRECATED] See OMNITRACE_PERFETTO_FILE", std::string{},
                              "perfetto", "io", "filename", "deprecated");
+
     OMNITRACE_CONFIG_SETTING(std::string, "OMNITRACE_PERFETTO_FILE", "Perfetto filename",
                              std::string{ "perfetto-trace.proto" }, "perfetto", "io",
                              "filename");
@@ -694,7 +733,7 @@ configure_signal_handler()
         using sys_signal      = tim::sys_signal;
         tim::disable_signal_detection();
         auto _exit_action = [](int nsig) {
-            tim::sampling::block_signals({ SIGPROF, SIGRTMIN },
+            tim::sampling::block_signals(get_sampling_signals(),
                                          tim::sampling::sigmask_scope::process);
             OMNITRACE_BASIC_PRINT(
                 "Finalizing afer signal %i :: %s\n", nsig,
@@ -1315,6 +1354,34 @@ get_critical_trace_serialize_names()
 }
 
 bool
+get_sampling_keep_internal()
+{
+    static auto _v = get_config()->find("OMNITRACE_SAMPLING_KEEP_INTERNAL");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+}
+
+bool
+get_use_sampling_realtime()
+{
+    static auto _v = get_config()->find("OMNITRACE_SAMPLING_REALTIME");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+}
+
+bool
+get_use_sampling_cputime()
+{
+    static auto _v = get_config()->find("OMNITRACE_SAMPLING_CPUTIME");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+}
+
+int
+get_sampling_rtoffset()
+{
+    static auto _v = get_config()->find("OMNITRACE_SAMPLING_REALTIME_OFFSET");
+    return static_cast<tim::tsettings<int>&>(*_v->second).get();
+}
+
+bool
 get_timeline_sampling()
 {
     static auto _v = get_config()->find("OMNITRACE_TIMELINE_SAMPLING");
@@ -1475,7 +1542,7 @@ get_instrumentation_interval()
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
-double&
+double
 get_sampling_freq()
 {
     static auto _v = get_config()->find("OMNITRACE_SAMPLING_FREQ");
@@ -1503,11 +1570,14 @@ get_critical_trace_count()
     return static_cast<tim::tsettings<int64_t>&>(*_v->second).get();
 }
 
-double&
+double
 get_process_sampling_freq()
 {
-    static auto _v = std::min<double>(get_sampling_freq(), 1000.0);
-    return _v;
+    static auto _v = get_config()->find("OMNITRACE_PROCESS_SAMPLING_FREQ");
+    auto        _val =
+        std::min<double>(static_cast<tim::tsettings<double>&>(*_v->second).get(), 1000.0);
+    if(_val < 1.0e-9) return get_sampling_freq();
+    return _val;
 }
 
 std::string

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -205,6 +205,18 @@ bool
 get_use_code_coverage();
 
 bool
+get_sampling_keep_internal();
+
+bool
+get_use_sampling_realtime();
+
+bool
+get_use_sampling_cputime();
+
+int
+get_sampling_rtoffset();
+
+bool
 get_timeline_sampling();
 
 bool
@@ -265,7 +277,7 @@ get_critical_trace_count();
 size_t&
 get_instrumentation_interval();
 
-double&
+double
 get_sampling_freq();
 
 double&
@@ -274,7 +286,7 @@ get_sampling_delay();
 std::string
 get_sampling_cpus();
 
-double&
+double
 get_process_sampling_freq();
 
 std::string

--- a/source/lib/omnitrace/library/runtime.hpp
+++ b/source/lib/omnitrace/library/runtime.hpp
@@ -34,6 +34,7 @@
 #include "library/timemory.hpp"
 
 #include <memory>
+#include <set>
 #include <timemory/backends/threading.hpp>
 #include <timemory/macros/language.hpp>
 
@@ -66,6 +67,15 @@ get_main_bundle();
 
 std::unique_ptr<gotcha_bundle_t>&
 get_gotcha_bundle();
+
+int
+get_realtime_signal();
+
+int
+get_cputime_signal();
+
+std::set<int>
+get_sampling_signals(int64_t _tid = 0);
 
 std::atomic<uint64_t>&
 get_cpu_cid() TIMEMORY_HOT;

--- a/source/lib/omnitrace/library/sampling.cpp
+++ b/source/lib/omnitrace/library/sampling.cpp
@@ -124,9 +124,9 @@ unique_ptr_t<std::set<int>>&
 get_signal_types(int64_t _tid)
 {
     static auto& _v = signal_type_instances::instances();
-    // on the main thread, use both SIGALRM and SIGPROF.
+    // on the main thread, use both SIGRTMIN and SIGPROF.
     // on secondary threads, only use SIGPROF.
-    signal_type_instances::construct((_tid == 0) ? std::set<int>{ SIGALRM, SIGPROF }
+    signal_type_instances::construct((_tid == 0) ? std::set<int>{ SIGRTMIN, SIGPROF }
                                                  : std::set<int>{ SIGPROF });
     return _v.at(_tid);
 }

--- a/source/lib/omnitrace/library/sampling.cpp
+++ b/source/lib/omnitrace/library/sampling.cpp
@@ -25,6 +25,7 @@
 #include "library/config.hpp"
 #include "library/debug.hpp"
 #include "library/ptl.hpp"
+#include "library/runtime.hpp"
 
 #include <timemory/backends/papi.hpp>
 #include <timemory/backends/threading.hpp>
@@ -124,10 +125,7 @@ unique_ptr_t<std::set<int>>&
 get_signal_types(int64_t _tid)
 {
     static auto& _v = signal_type_instances::instances();
-    // on the main thread, use both SIGRTMIN and SIGPROF.
-    // on secondary threads, only use SIGPROF.
-    signal_type_instances::construct((_tid == 0) ? std::set<int>{ SIGRTMIN, SIGPROF }
-                                                 : std::set<int>{ SIGPROF });
+    signal_type_instances::construct(omnitrace::get_sampling_signals(_tid));
     return _v.at(_tid);
 }
 


### PR DESCRIPTION
- Prefer using SIGRTMIN + N signals instead of SIGALRM
- OMNITRACE_SAMPLING_KEEP_INTERNAL config option
- OMNITRACE_PROCESS_SAMPLING_FREQ config option
- OMNITRACE_SAMPLING_REALTIME config option
- OMNITRACE_SAMPLING_CPUTIME config option
- OMNITRACE_SAMPLING_REALTIME_OFFSET config option