### PR TITLE
ubuntu cpack was building for rocm 5.2 twice

### DIFF
--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -128,9 +128,6 @@ do
             ROCM_REPO_DIST="ubuntu"
             ROCM_REPO_VERSION=${i}
             case "${i}" in
-                5.1*)
-                    ROCM_REPO_VERSION="debian"
-                    ;;
                 4.1* | 4.0*)
                     ROCM_REPO_DIST="xenial"
                     ;;


### PR DESCRIPTION
- fixes issue where ubuntu cpack workflows for ROCm 5.1 and 5.2 were both building ROCm 5.2