### PR TITLE
Fix RPATH handling

### DIFF
--- a/cmake/MacroUtilities.cmake
+++ b/cmake/MacroUtilities.cmake
@@ -319,27 +319,6 @@ macro(OMNITRACE_ADD_INTERFACE_LIBRARY _TARGET)
     endif()
 endmacro()
 
-function(OMNITRACE_ADD_RPATH)
-    set(_DIRS)
-    foreach(_ARG ${ARGN})
-        if(EXISTS "${_ARG}" AND IS_DIRECTORY "${_ARG}")
-            list(APPEND _DIRS "${_ARG}")
-        endif()
-        get_filename_component(_DIR "${_ARG}" DIRECTORY)
-        if(EXISTS "${_DIR}" AND IS_DIRECTORY "${_DIR}")
-            list(APPEND _DIRS "${_DIR}")
-        endif()
-    endforeach()
-    if(_DIRS)
-        list(REMOVE_DUPLICATES _DIRS)
-        string(REPLACE ";" ":" _RPATH "${_DIRS}")
-        # message(STATUS "\n\tRPATH additions: ${_RPATH}\n")
-        set(CMAKE_INSTALL_RPATH
-            "${CMAKE_INSTALL_RPATH}:${_RPATH}"
-            PARENT_SCOPE)
-    endif()
-endfunction()
-
 # -----------------------------------------------------------------------
 # function add_feature(<NAME> <DOCSTRING>) Add a project feature, whose activation is
 # specified by the existence of the variable <NAME>, to the list of enabled/disabled

--- a/cmake/Packages.cmake
+++ b/cmake/Packages.cmake
@@ -169,7 +169,6 @@ if(OMNITRACE_USE_ROCTRACER)
                                          INTERFACE OMNITRACE_USE_ROCTRACER)
     target_link_libraries(omnitrace-roctracer INTERFACE roctracer::roctracer
                                                         omnitrace::omnitrace-hip)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${roctracer_LIBRARY_DIRS}")
 endif()
 
 # ----------------------------------------------------------------------------------------#
@@ -182,7 +181,6 @@ if(OMNITRACE_USE_ROCPROFILER)
     omnitrace_target_compile_definitions(omnitrace-rocprofiler
                                          INTERFACE OMNITRACE_USE_ROCPROFILER)
     target_link_libraries(omnitrace-rocprofiler INTERFACE rocprofiler::rocprofiler)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${rocprofiler_LIBRARY_DIRS}")
 endif()
 
 # ----------------------------------------------------------------------------------------#
@@ -196,7 +194,6 @@ if(OMNITRACE_USE_ROCM_SMI)
     omnitrace_target_compile_definitions(omnitrace-rocm-smi
                                          INTERFACE OMNITRACE_USE_ROCM_SMI)
     target_link_libraries(omnitrace-rocm-smi INTERFACE rocm-smi::rocm-smi)
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${rocm-smi_LIBRARY_DIRS}")
 endif()
 
 # ----------------------------------------------------------------------------------------#
@@ -348,7 +345,6 @@ else()
                 omnitrace-dyninst INTERFACE DYNINST_API_RT="${OMNITRACE_DYNINST_API_RT}")
         endif()
 
-        omnitrace_add_rpath(${Dyninst_LIBRARIES})
         target_link_libraries(omnitrace-dyninst INTERFACE Dyninst::Dyninst)
     else() # updated Dyninst CMake system was not found
         set(_BOOST_COMPONENTS atomic system thread date_time)
@@ -399,15 +395,6 @@ else()
                 omnitrace-dyninst INTERFACE DYNINST_API_RT="${OMNITRACE_DYNINST_API_RT}")
         endif()
 
-        if(Boost_DIR)
-            get_filename_component(Boost_RPATH_DIR "${Boost_DIR}" DIRECTORY)
-            get_filename_component(Boost_RPATH_DIR "${Boost_RPATH_DIR}" DIRECTORY)
-            if(EXISTS "${Boost_RPATH_DIR}" AND IS_DIRECTORY "${Boost_RPATH_DIR}")
-                set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${Boost_RPATH_DIR}")
-            endif()
-        endif()
-
-        omnitrace_add_rpath(${DYNINST_LIBRARIES} ${Boost_LIBRARIES})
         target_link_libraries(omnitrace-dyninst INTERFACE ${DYNINST_LIBRARIES}
                                                           ${Boost_LIBRARIES})
         foreach(

--- a/source/bin/omnitrace-avail/CMakeLists.txt
+++ b/source/bin/omnitrace-avail/CMakeLists.txt
@@ -28,10 +28,8 @@ target_compile_definitions(omnitrace-avail PRIVATE OMNITRACE_EXTERN_COMPONENTS=0
 target_link_libraries(omnitrace-avail PRIVATE omnitrace::omnitrace-compile-definitions
                                               omnitrace::omnitrace-interface-library)
 set_target_properties(
-    omnitrace-avail
-    PROPERTIES BUILD_RPATH "\$ORIGIN:${PROJECT_BINARY_DIR}:${CMAKE_BINARY_DIR}"
-               INSTALL_RPATH_USE_LINK_PATH ON
-               INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")
+    omnitrace-avail PROPERTIES BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
+                               INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")
 
 install(
     TARGETS omnitrace-avail

--- a/source/bin/omnitrace-critical-trace/CMakeLists.txt
+++ b/source/bin/omnitrace-critical-trace/CMakeLists.txt
@@ -19,8 +19,7 @@ target_link_libraries(
             omnitrace::omnitrace-timemory)
 set_target_properties(
     omnitrace-critical-trace
-    PROPERTIES BUILD_RPATH "\$ORIGIN:${PROJECT_BINARY_DIR}:${CMAKE_BINARY_DIR}"
-               INSTALL_RPATH_USE_LINK_PATH ON
+    PROPERTIES BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")
 
 install(

--- a/source/bin/omnitrace/CMakeLists.txt
+++ b/source/bin/omnitrace/CMakeLists.txt
@@ -32,8 +32,7 @@ target_link_libraries(
 set_target_properties(
     omnitrace-exe
     PROPERTIES OUTPUT_NAME omnitrace
-               BUILD_RPATH "\$ORIGIN:${PROJECT_BINARY_DIR}:${CMAKE_BINARY_DIR}"
-               INSTALL_RPATH_USE_LINK_PATH ON
+               BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")
 
 if(OMNITRACE_BUILD_DYNINST)

--- a/source/lib/CMakeLists.txt
+++ b/source/lib/CMakeLists.txt
@@ -8,13 +8,7 @@
 #
 # ----------------------------------------------------------------------------- #
 
-string(REPLACE ":" ";" _INSTALL_RPATH "${CMAKE_INSTALL_RPATH}")
-if(_INSTALL_RPATH)
-    list(REMOVE_DUPLICATES _INSTALL_RPATH)
-endif()
-string(REPLACE ";" ":" _INSTALL_RPATH "${_INSTALL_RPATH}")
-string(REPLACE "::" ":" OMNITRACE_LIB_INSTALL_RPATH
-               "\$ORIGIN:\$ORIGIN/omnitrace:${_INSTALL_RPATH}")
+set(OMNITRACE_LIB_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/omnitrace")
 
 add_subdirectory(common)
 add_subdirectory(omnitrace)

--- a/source/python/CMakeLists.txt
+++ b/source/python/CMakeLists.txt
@@ -35,7 +35,6 @@ function(OMNITRACE_CONFIGURE_PYTARGET _TARGET _VERSION)
                    ${PROJECT_BINARY_DIR}/lib/python/site-packages/omnitrace
                    PDB_OUTPUT_DIRECTORY
                    ${PROJECT_BINARY_DIR}/lib/python/site-packages/omnitrace
-                   INSTALL_RPATH_USE_LINK_PATH ON
                    ${EXTRA_PROPERTIES})
 
     set(_PYLIB ${CMAKE_INSTALL_PYTHONDIR}/omnitrace)
@@ -50,12 +49,8 @@ function(OMNITRACE_CONFIGURE_PYTARGET _TARGET _VERSION)
              "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
     endif()
 
-    set_target_properties(
-        ${_TARGET}
-        PROPERTIES
-            INSTALL_RPATH
-            "\$ORIGIN:\$ORIGIN/${LIB_RELPATH}:\$ORIGIN/../../../..:${CMAKE_INSTALL_RPATH}"
-        )
+    set_target_properties(${_TARGET} PROPERTIES INSTALL_RPATH
+                                                "\$ORIGIN:\$ORIGIN/${LIB_RELPATH}")
 
     install(
         TARGETS ${_TARGET}


### PR DESCRIPTION
- remove explicit add to CMAKE_INSTALL_RPATH
- remove overriding INSTALL_RPATH_USE_LINK_PATH for exes
- closes #121 