### PR TITLE
RPATH to rocprofiler_LIBRARY_DIR for ROCm < v5.2

### DIFF
--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -222,7 +222,7 @@ jobs:
         echo "CC=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g')" >> $GITHUB_ENV
         echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=/opt/dyninst:${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/opt/rocm/lib:/opt/dyninst/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
         cat << EOF > test-install.cfg
         OMNITRACE_USE_TIMEMORY          = ON
         OMNITRACE_USE_PERFETTO          = ON

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -221,8 +221,8 @@ jobs:
       run: |
         echo "CC=$(echo '${{ matrix.compiler }}' | sed 's/+/c/g')" >> $GITHUB_ENV
         echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
-        echo "CMAKE_PREFIX_PATH=/opt/dyninst:/opt/elfutils:${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/opt/dyninst/lib:/opt/elfutils/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        echo "CMAKE_PREFIX_PATH=/opt/dyninst:${CMAKE_PREFIX_PATH}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:/opt/dyninst/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
         cat << EOF > test-install.cfg
         OMNITRACE_USE_TIMEMORY          = ON
         OMNITRACE_USE_PERFETTO          = ON
@@ -268,6 +268,7 @@ jobs:
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
           -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
           -DOMNITRACE_CI_MPI_RUN_AS_ROOT=${{ matrix.mpi_headers }}
+          -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF
 
     - name: Build
       timeout-minutes: 60

--- a/cmake/Modules/Findrocprofiler.cmake
+++ b/cmake/Modules/Findrocprofiler.cmake
@@ -48,6 +48,7 @@ find_path(
 mark_as_advanced(rocprofiler_hsa_INCLUDE_DIR)
 
 # ----------------------------------------------------------------------------------------#
+
 find_library(
     rocprofiler_LIBRARY
     NAMES rocprofiler64 rocprofiler
@@ -70,13 +71,15 @@ if(rocprofiler_LIBRARY)
 endif()
 
 mark_as_advanced(rocprofiler_LIBRARY rocprofiler_hsa-runtime_LIBRARY)
+unset(_ROCM_ROCPROFILER_PATHS)
 
 # ----------------------------------------------------------------------------------------#
+
 find_package_handle_standard_args(
     rocprofiler DEFAULT_MSG rocprofiler_ROOT_DIR rocprofiler_INCLUDE_DIR
     rocprofiler_hsa_INCLUDE_DIR rocprofiler_LIBRARY rocprofiler_hsa-runtime_LIBRARY)
 
-# ------------------------------------------------------------------------------#
+# ----------------------------------------------------------------------------------------#
 
 if(rocprofiler_FOUND)
     add_library(rocprofiler::rocprofiler INTERFACE IMPORTED)
@@ -92,8 +95,3 @@ if(rocprofiler_FOUND)
 
     target_link_libraries(rocprofiler::rocprofiler INTERFACE ${rocprofiler_LIBRARIES})
 endif()
-# ------------------------------------------------------------------------------#
-
-unset(_ROCM_ROCPROFILER_PATHS)
-
-# ------------------------------------------------------------------------------#

--- a/source/bin/CMakeLists.txt
+++ b/source/bin/CMakeLists.txt
@@ -1,6 +1,17 @@
 # executable RPATH
-set(OMNITRACE_EXE_INSTALL_RPATH
-    "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/omnitrace")
+
+if(OMNITRACE_USE_ROCPROFILER
+   AND rocprofiler_LIBRARY_DIR
+   AND ROCmVersion_TRIPLE_VERSION VERSION_LESS 5.2.0
+   AND NOT CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+    set(OMNITRACE_EXE_INSTALL_RPATH
+        "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/omnitrace:${rocprofiler_LIBRARY_DIR}"
+        )
+else()
+    set(OMNITRACE_EXE_INSTALL_RPATH
+        "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}/omnitrace"
+        )
+endif()
 
 # executables
 add_subdirectory(omnitrace-avail)

--- a/source/bin/omnitrace/CMakeLists.txt
+++ b/source/bin/omnitrace/CMakeLists.txt
@@ -33,7 +33,8 @@ set_target_properties(
     omnitrace-exe
     PROPERTIES OUTPUT_NAME omnitrace
                BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
-               INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")
+               INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}"
+               INSTALL_RPATH_USE_LINK_PATH ON)
 
 if(OMNITRACE_BUILD_DYNINST)
     target_compile_definitions(omnitrace-exe PRIVATE OMNITRACE_BUILD_DYNINST=1)

--- a/source/lib/CMakeLists.txt
+++ b/source/lib/CMakeLists.txt
@@ -8,7 +8,15 @@
 #
 # ----------------------------------------------------------------------------- #
 
-set(OMNITRACE_LIB_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/omnitrace")
+if(OMNITRACE_USE_ROCPROFILER
+   AND rocprofiler_LIBRARY_DIR
+   AND ROCmVersion_TRIPLE_VERSION VERSION_LESS 5.2.0
+   AND NOT CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+    set(OMNITRACE_LIB_INSTALL_RPATH
+        "\$ORIGIN:\$ORIGIN/omnitrace:${rocprofiler_LIBRARY_DIR}")
+else()
+    set(OMNITRACE_LIB_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/omnitrace")
+endif()
 
 add_subdirectory(common)
 add_subdirectory(omnitrace)


### PR DESCRIPTION
- until v5.2 only librocprofiler64.so was symlinked in /opt/rocm. Thus linker using SOVERSION caused issues finding librocprofiler64.so.1
- closes #121 