### PR TITLE
OMNITRACE_TRACE_THREAD_SPIN_LOCKS config

### DIFF
--- a/source/lib/omnitrace/library/components/pthread_mutex_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_mutex_gotcha.cpp
@@ -65,6 +65,11 @@ pthread_mutex_gotcha::get_hashes()
             for(size_t i = 3; i < 8; ++i)
                 _skip.emplace(i);
         }
+        if(!config::get_trace_thread_spin_locks())
+        {
+            for(size_t i = 9; i < 12; ++i)
+                _skip.emplace(i);
+        }
         for(size_t i = 0; i < gotcha_capacity; ++i)
         {
             auto&& _id = _data.at(i).tool_id;
@@ -131,14 +136,19 @@ pthread_mutex_gotcha::configure()
         pthread_mutex_gotcha_t::configure(
             comp::gotcha_config<8, int, pthread_barrier_t*>{ "pthread_barrier_wait" });
 
-        pthread_mutex_gotcha_t::configure(
-            comp::gotcha_config<9, int, pthread_spinlock_t*>{ "pthread_spin_lock" });
+        if(config::get_trace_thread_spin_locks())
+        {
+            pthread_mutex_gotcha_t::configure(
+                comp::gotcha_config<9, int, pthread_spinlock_t*>{ "pthread_spin_lock" });
 
-        pthread_mutex_gotcha_t::configure(
-            comp::gotcha_config<10, int, pthread_spinlock_t*>{ "pthread_spin_trylock" });
+            pthread_mutex_gotcha_t::configure(
+                comp::gotcha_config<10, int, pthread_spinlock_t*>{
+                    "pthread_spin_trylock" });
 
-        pthread_mutex_gotcha_t::configure(
-            comp::gotcha_config<11, int, pthread_spinlock_t*>{ "pthread_spin_unlock" });
+            pthread_mutex_gotcha_t::configure(
+                comp::gotcha_config<11, int, pthread_spinlock_t*>{
+                    "pthread_spin_unlock" });
+        }
 
         pthread_mutex_gotcha_t::configure(
             comp::gotcha_config<12, int, pthread_t, void**>{ "pthread_join" });

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -358,6 +358,11 @@ configure_settings(bool _init)
                              "cause deadlocks with ROCm-enabled OpenMPI.",
                              false, "backend", "parallelism", "gotcha", "advanced");
 
+    OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_TRACE_THREAD_SPIN_LOCKS",
+                             "Enable tracing calls to pthread_spin_* functions. May "
+                             "cause deadlocks with MPI distributions.",
+                             false, "backend", "parallelism", "gotcha", "advanced");
+
     OMNITRACE_CONFIG_SETTING(
         bool, "OMNITRACE_SAMPLING_KEEP_INTERNAL",
         "Configure whether the statistical samples should include call-stack entries "
@@ -1726,6 +1731,13 @@ bool
 get_trace_thread_rwlocks()
 {
     static auto _v = get_config()->find("OMNITRACE_TRACE_THREAD_RW_LOCKS");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+}
+
+bool
+get_trace_thread_spin_locks()
+{
+    static auto _v = get_config()->find("OMNITRACE_TRACE_THREAD_SPIN_LOCKS");
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -304,6 +304,9 @@ get_trace_thread_locks();
 bool
 get_trace_thread_rwlocks();
 
+bool
+get_trace_thread_spin_locks();
+
 std::string
 get_rocm_events();
 }  // namespace config


### PR DESCRIPTION
- `OMNITRACE_TRACE_THREAD_SPIN_LOCKS` configuration setting to wrap `pthread_spin_lock`, `pthread_spin_trylock`, `pthread_spin_unlock`