### PR TITLE
Python noprofile

### DIFF
--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
 
 project(omnitrace-python)
 
-set(PYTHON_FILES builtin.py external.py source.py)
+set(PYTHON_FILES builtin.py external.py source.py noprofile.py)
 
 if(OMNITRACE_INSTALL_EXAMPLES)
     find_package(Python3 COMPONENTS Interpreter)

--- a/examples/python/noprofile.py
+++ b/examples/python/noprofile.py
@@ -1,0 +1,50 @@
+#!@PYTHON_EXECUTABLE@
+
+import os
+import sys
+import random
+
+_prefix = ""
+
+
+@noprofile
+def fib(n):
+    return n if n < 2 else (fib(n - 1) + fib(n - 2))
+
+
+@noprofile
+def inefficient(n):
+    print(f"[{_prefix}] ... running inefficient({n})")
+    a = 0
+    for i in range(n):
+        a += i
+        for j in range(n):
+            a += j
+    _len = a * n * n * n
+    _arr = [random.random() for _ in range(_len)]
+    _sum = sum(_arr)
+    print(f"[{_prefix}] ... sum of {_len} random elements: {_sum}")
+    return _sum
+
+
+@profile
+def run(n):
+    _ret = 0
+    _ret += fib(n)
+    _ret += inefficient(n)
+    return _ret
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-n", "--num-iterations", help="Number", type=int, default=3)
+    parser.add_argument("-v", "--value", help="Starting value", type=int, default=20)
+    args = parser.parse_args()
+
+    _prefix = os.path.basename(__file__)
+    print(f"[{_prefix}] Executing {args.num_iterations} iterations...\n")
+    for i in range(args.num_iterations):
+        ans = run(args.value)
+        print(f"[{_prefix}] [{i}] result of run({args.value}) = {ans}\n")

--- a/source/python/libpyomnitrace.cpp
+++ b/source/python/libpyomnitrace.cpp
@@ -513,21 +513,21 @@ generate(py::module& _pymod)
         get_config().records.clear();
     };
 
-    static auto _sys        = py::module::import("sys");
-    static auto _setprofile = _sys.attr("setprofile");
+    auto _sys        = py::module::import("sys");
+    auto _setprofile = _sys.attr("setprofile");
 
     _prof.def("profiler_function", &profiler_function, "Profiling function");
     _prof.def("profiler_init", _init, "Initialize the profiler");
     _prof.def("profiler_finalize", _fini, "Finalize the profiler");
     _prof.def(
         "profiler_pause",
-        []() {
+        [_setprofile]() {
             if(++get_paused() == 1) _setprofile(nullptr);
         },
         "Pause the profiler");
     _prof.def(
         "profiler_resume",
-        []() {
+        [_setprofile]() {
             if(--get_paused() == 0) _setprofile(py::cpp_function{ profiler_function });
         },
         "Resume the profiler");

--- a/source/python/libpyomnitrace.cpp
+++ b/source/python/libpyomnitrace.cpp
@@ -187,6 +187,13 @@ strset_t default_exclude_functions = { "^<.*>$" };
 strset_t default_exclude_filenames = { "(encoder|decoder|threading).py$", "^<.*>$" };
 }  // namespace
 //
+auto&
+get_paused()
+{
+    static thread_local int64_t _v = 0;
+    return _v;
+}
+//
 struct config
 {
     bool                    is_running         = false;
@@ -251,6 +258,8 @@ get_depth(PyFrameObject* frame)
 void
 profiler_function(py::object pframe, const char* swhat, py::object arg)
 {
+    if(get_paused() > 0) return;
+
     static thread_local auto& _config  = get_config();
     static thread_local auto  _disable = false;
 
@@ -504,9 +513,24 @@ generate(py::module& _pymod)
         get_config().records.clear();
     };
 
+    static auto _sys        = py::module::import("sys");
+    static auto _setprofile = _sys.attr("setprofile");
+
     _prof.def("profiler_function", &profiler_function, "Profiling function");
     _prof.def("profiler_init", _init, "Initialize the profiler");
     _prof.def("profiler_finalize", _fini, "Finalize the profiler");
+    _prof.def(
+        "profiler_pause",
+        []() {
+            if(++get_paused() == 1) _setprofile(nullptr);
+        },
+        "Pause the profiler");
+    _prof.def(
+        "profiler_resume",
+        []() {
+            if(--get_paused() == 0) _setprofile(py::cpp_function{ profiler_function });
+        },
+        "Resume the profiler");
 
     py::class_<config> _pyconfig(_prof, "config", "Profiler configuration");
 

--- a/source/python/pyproject.toml
+++ b/source/python/pyproject.toml
@@ -7,6 +7,6 @@ requires = [
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
-line-length = 80
+line-length = 90
 target-version = ['py38']
 include = '\.py'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1230,6 +1230,15 @@ foreach(_VERSION ${OMNITRACE_PYTHON_VERSIONS})
         ENVIRONMENT "${_python_environment}")
 
     omnitrace_add_python_test(
+        NAME python-builtin-noprofile
+        PYTHON_EXECUTABLE ${_PYTHON_EXECUTABLE}
+        PYTHON_VERSION ${_VERSION}
+        FILE ${CMAKE_SOURCE_DIR}/examples/python/noprofile.py
+        PROFILE_ARGS "-b" "--label" "file"
+        RUN_ARGS -v 15 -n 5
+        ENVIRONMENT "${_python_environment}")
+
+    omnitrace_add_python_test(
         STANDALONE
         NAME python-source
         PYTHON_EXECUTABLE ${_PYTHON_EXECUTABLE}
@@ -1281,6 +1290,16 @@ foreach(_VERSION ${OMNITRACE_PYTHON_VERSIONS})
             FILE omnitrace-tests-output/python-builtin/${_VERSION}/trip_count.txt
             PASS_REGEX "\\\[inefficient\\\]\\\[builtin.py:14\\\]"
             DEPENDS python-builtin-${_VERSION}
+            ENVIRONMENT "${_python_environment}")
+
+        omnitrace_add_python_test(
+            NAME python-builtin-noprofile-check
+            COMMAND ${OMNITRACE_CAT_COMMAND}
+            PYTHON_VERSION ${_VERSION}
+            FILE omnitrace-tests-output/python-builtin-noprofile/${_VERSION}/trip_count.txt
+            PASS_REGEX ".(run)..(noprofile.py)."
+            FAIL_REGEX ".(fib|inefficient)..(noprofile.py)."
+            DEPENDS python-builtin-noprofile-${_VERSION}
             ENVIRONMENT "${_python_environment}")
     else()
         omnitrace_message(


### PR DESCRIPTION
- `omnitrace.libpyomnitrace.profiler.profiler_pause()`
- `omnitrace.libpyomnitrace.profiler.profiler_resume()`
- Testing for noprofile

## Example

In the below, `bar` will show up in the profile but `foo` will not. Using `@noprofile` (or corresponding context-manager) will result in less overhead vs. over excluding functions via command-line regex in `omnitrace-python`

```python
@noprofile
def foo():
    pass

@profile
def bar():
    foo()
```
