### PR TITLE
Individual perfetto debug annotations

### DIFF
--- a/source/lib/omnitrace/library/components/category_region.hpp
+++ b/source/lib/omnitrace/library/components/category_region.hpp
@@ -248,10 +248,10 @@ void
 category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
                                   Args&&... _args)
 {
-    start<OptsT...>(
-        _data.tool_id.c_str(), "args",
-        JOIN(", ",
-             JOIN('=', tim::try_demangle<std::remove_reference_t<Args>>(), _args)...));
+    start<OptsT...>(_data.tool_id.c_str(), [&](perfetto::EventContext ctx) {
+        OMNITRACE_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
+            ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args));
+    });
 }
 
 template <typename CategoryT>
@@ -269,10 +269,10 @@ void
 category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
                                   Args&&... _args)
 {
-    start<OptsT...>(
-        _name.data(), "args",
-        JOIN(", ",
-             JOIN('=', tim::try_demangle<std::remove_reference_t<Args>>(), _args)...));
+    start<OptsT...>(_name.data(), [&](perfetto::EventContext ctx) {
+        OMNITRACE_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
+            ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args));
+    });
 }
 
 template <typename CategoryT>

--- a/source/lib/omnitrace/library/concepts.hpp
+++ b/source/lib/omnitrace/library/concepts.hpp
@@ -64,5 +64,22 @@ struct is_optional : std::false_type
 template <typename Tp>
 struct is_optional<std::optional<Tp>> : std::true_type
 {};
+
+template <typename Tp>
+struct can_stringify
+{
+private:
+    static constexpr auto sfinae(int)
+        -> decltype(std::declval<std::ostream&>() << std::declval<Tp>(), bool())
+    {
+        return true;
+    }
+
+    static constexpr auto sfinae(long) { return false; }
+
+public:
+    static constexpr bool value = sfinae(0);
+    constexpr auto        operator()() const { return sfinae(0); }
+};
 }  // namespace concepts
 }  // namespace tim


### PR DESCRIPTION
- instead of args="<list-of-string>" in perfetto, each argument is added individually, enabling matching pointer values, etc.

## Previous behavior

Previously, all function arguments were wrapped into a single string, e.g.:

![Screen Shot 2022-09-12 at 11 52 11 PM](https://user-images.githubusercontent.com/6001865/189811896-3b13d5a4-e884-40b3-b6b4-f84f3e16f603.png)

## New Behavior

With the exception of the HIP API (whose args are provided as a single string via `hipApiString`), all functions from MPI, RCCL, pthreads, etc. have individual arguments in perfetto, e.g.:

![Screen Shot 2022-09-12 at 11 52 01 PM](https://user-images.githubusercontent.com/6001865/189812137-63afba72-170d-42b3-b3bc-ae74e32ceadf.png)

In the above, previously, this would have been:

|  |  |
| - | - |
| args | `pthread_rwlock_t*=0x1c1cc50` |

The key benefit enabled is the ability to find slices with same arg values:

<img width="753" alt="Screen Shot 2022-09-12 at 11 59 18 PM" src="https://user-images.githubusercontent.com/6001865/189812915-0342f841-e5ce-4f8e-8169-0cb52f3425b5.png">

Previously, the entire "args" field would have had to match, which essentially never happened if the pointer was used in two different functions with different function signatures

## Example

![Screen Shot 2022-09-12 at 11 49 18 PM](https://user-images.githubusercontent.com/6001865/189811621-5eed0008-f340-438e-938d-a140f836b583.png)

![Screen Shot 2022-09-12 at 11 49 45 PM](https://user-images.githubusercontent.com/6001865/189811584-a983ed1c-095f-4d54-a790-9ef3adbe4e08.png)
