### PR TITLE
Fix gotcha indexes for numa_gotcha

### DIFF
--- a/source/lib/omnitrace/library/components/numa_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/numa_gotcha.cpp
@@ -74,10 +74,10 @@ numa_gotcha::configure()
                                  int>("numa_move_pages");
         numa_gotcha_t::configure<5, void*, size_t>("numa_alloc");
         numa_gotcha_t::configure<6, void*, size_t>("numa_alloc_local");
-        numa_gotcha_t::configure<6, void*, size_t>("numa_alloc_interleaved");
-        numa_gotcha_t::configure<7, void*, size_t, int>("numa_alloc_onnode");
-        numa_gotcha_t::configure<8, void*, void*, size_t, size_t>("numa_realloc");
-        numa_gotcha_t::configure<9, void, void*, size_t>("numa_free");
+        numa_gotcha_t::configure<7, void*, size_t>("numa_alloc_interleaved");
+        numa_gotcha_t::configure<8, void*, size_t, int>("numa_alloc_onnode");
+        numa_gotcha_t::configure<9, void*, void*, size_t, size_t>("numa_realloc");
+        numa_gotcha_t::configure<10, void, void*, size_t>("numa_free");
     };
 }
 

--- a/source/lib/omnitrace/library/components/numa_gotcha.hpp
+++ b/source/lib/omnitrace/library/components/numa_gotcha.hpp
@@ -38,7 +38,7 @@ namespace component
 {
 struct numa_gotcha : tim::component::base<numa_gotcha, void>
 {
-    static constexpr size_t gotcha_capacity = 10;
+    static constexpr size_t gotcha_capacity = 11;
 
     using gotcha_data  = tim::component::gotcha_data;
     using exit_func_t  = void (*)(int);


### PR DESCRIPTION
- In #152, `numa_alloc_interleaved` and `numa_alloc_local` both were indexed at position 6