### PR TITLE
Raise default min number of instructions

### DIFF
--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -54,6 +54,10 @@ else()
     target_compile_options(transpose PRIVATE -W -Wall)
 endif()
 
+if("${CMAKE_BUILD_TYPE}" MATCHES "Release")
+    target_compile_options(transpose PRIVATE -g1)
+endif()
+
 if(TRANSPOSE_USE_MPI)
     target_compile_definitions(transpose PRIVATE USE_MPI)
     target_link_libraries(transpose PRIVATE MPI::MPI_C)

--- a/source/bin/omnitrace/omnitrace.cpp
+++ b/source/bin/omnitrace/omnitrace.cpp
@@ -64,6 +64,22 @@
 #    define OMNITRACE_USE_MPI_HEADERS 0
 #endif
 
+namespace
+{
+auto
+get_default_min_instructions()
+{
+    // default to 1024
+    return tim::get_env<size_t>("OMNITRACE_DEFAULT_MIN_INSTRUCTIONS", (1 << 10), false);
+}
+auto
+get_default_min_address_range()
+{
+    // default to 4096
+    return 4 * get_default_min_instructions();
+}
+}  // namespace
+
 bool     use_return_info         = false;
 bool     use_args_info           = false;
 bool     use_file_info           = false;
@@ -73,10 +89,10 @@ bool     loop_level_instr        = false;
 bool     instr_dynamic_callsites = false;
 bool     instr_traps             = false;
 bool     instr_loop_traps        = false;
-size_t   min_address_range       = (1 << 8);  // 256
-size_t   min_loop_address_range  = (1 << 8);  // 256
-size_t   min_instructions        = (1 << 6);  // 64
-size_t   min_loop_instructions   = (1 << 6);  // 64
+size_t   min_address_range       = get_default_min_address_range();  // 4096
+size_t   min_loop_address_range  = get_default_min_address_range();  // 4096
+size_t   min_instructions        = get_default_min_instructions();   // 1024
+size_t   min_loop_instructions   = get_default_min_instructions();   // 1024
 bool     werror                  = false;
 bool     debug_print             = false;
 bool     instr_print             = false;

--- a/source/lib/omnitrace/library/debug.hpp
+++ b/source/lib/omnitrace/library/debug.hpp
@@ -531,6 +531,11 @@ get_chars(T&& _c, std::index_sequence<Idx...>)
                                            (::omnitrace::get_verbose_env() >= LEVEL),    \
                                        __VA_ARGS__)
 
+#define OMNITRACE_WARNING_IF(COND, ...) OMNITRACE_CONDITIONAL_WARN((COND), __VA_ARGS__)
+
+#define OMNITRACE_WARNING_IF_F(COND, ...)                                                \
+    OMNITRACE_CONDITIONAL_WARN_F((COND), __VA_ARGS__)
+
 //--------------------------------------------------------------------------------------//
 //
 //  Basic print macros (basic means it will not provide PID/RANK or TID) and will not

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,7 +193,9 @@ endif()
 # -------------------------------------------------------------------------------------- #
 
 function(OMNITRACE_WRITE_TEST_CONFIG _FILE _ENV)
-    set(_ENV_ONLY "OMNITRACE_(USE_MPIP|DEBUG_SETTINGS|FORCE_ROCPROFILER_INIT)=")
+    set(_ENV_ONLY
+        "OMNITRACE_(USE_MPIP|DEBUG_SETTINGS|FORCE_ROCPROFILER_INIT|DEFAULT_MIN_INSTRUCTIONS)="
+        )
     set(_FILE_CONTENTS)
     set(_ENV_CONTENTS)
 
@@ -393,7 +395,8 @@ function(OMNITRACE_ADD_TEST)
             endif()
 
             set(_environ
-                "${TEST_ENVIRONMENT}" "OMNITRACE_OUTPUT_PATH=omnitrace-tests-output"
+                "OMNITRACE_DEFAULT_MIN_INSTRUCTIONS=64" "${TEST_ENVIRONMENT}"
+                "OMNITRACE_OUTPUT_PATH=omnitrace-tests-output"
                 "OMNITRACE_OUTPUT_PREFIX=${_prefix}")
 
             set(_timeout ${TEST_REWRITE_TIMEOUT})


### PR DESCRIPTION
- Raise min instructions default to 1024 instead of 64
    - Default value of 64 has demonstrated tendency to slow down real-life applications
- Improved the memory safety during `omnitrace_finalize()`
    - new modifications guarantee that when `tim::manager::instance()` on main thread is destroyed, omnitrace will finalize before
- Improved some warning w/ roctracer
- Improved the search for `ROCP_METRICS` and `OMNITRACE_ROCPROFILER_LIBRARY`
- disable printing env by default
- Attempted to improve the sampling shutdown