### PR TITLE
Fix perfetto debug annotations of function parameters

### DIFF
--- a/source/lib/omnitrace/library/components/category_region.hpp
+++ b/source/lib/omnitrace/library/components/category_region.hpp
@@ -249,8 +249,9 @@ category_region<CategoryT>::audit(const gotcha_data_t& _data, audit::incoming,
                                   Args&&... _args)
 {
     start<OptsT...>(_data.tool_id.c_str(), [&](perfetto::EventContext ctx) {
+        int64_t _n = 0;
         OMNITRACE_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
-            ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args));
+            ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args, _n++));
     });
 }
 
@@ -270,8 +271,9 @@ category_region<CategoryT>::audit(std::string_view _name, audit::incoming,
                                   Args&&... _args)
 {
     start<OptsT...>(_name.data(), [&](perfetto::EventContext ctx) {
+        int64_t _n = 0;
         OMNITRACE_FOLD_EXPRESSION(tracing::add_perfetto_annotation(
-            ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args));
+            ctx, tim::try_demangle<std::remove_reference_t<Args>>(), _args, _n++));
     });
 }
 

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -202,7 +202,8 @@ pop_timemory(CategoryT, const char* name, Args&&... args)
 
 template <typename Np, typename Tp>
 auto
-add_perfetto_annotation(perfetto::EventContext& ctx, Np&& _name, Tp&& _val)
+add_perfetto_annotation(perfetto::EventContext& ctx, Np&& _name, Tp&& _val,
+                        int64_t _idx = -1)
 {
     using named_type = std::remove_reference_t<std::remove_cv_t<std::decay_t<Np>>>;
     using value_type = std::remove_reference_t<std::remove_cv_t<std::decay_t<Tp>>>;
@@ -212,7 +213,15 @@ add_perfetto_annotation(perfetto::EventContext& ctx, Np&& _name, Tp&& _val)
 
     auto _get_dbg = [&]() {
         auto* _dbg = ctx.event()->add_debug_annotations();
-        _dbg->set_name(std::string_view{ std::forward<Np>(_name) }.data());
+        if(_idx >= 0)
+        {
+            auto _arg_name = JOIN("", "arg", _idx, "-", std::forward<Np>(_name));
+            _dbg->set_name(_arg_name);
+        }
+        else
+        {
+            _dbg->set_name(std::string_view{ std::forward<Np>(_name) }.data());
+        }
         return _dbg;
     };
 


### PR DESCRIPTION
- The changes in #157 fail to handle situation where multiple arguments have the same type, e.g., `foo(int a, int b)` where `a=1` and `b=2` would result in one debug annotation `int: 1`
- Now include the position number of the argument, e.g. `arg1-int` and `arg2-int`.
- Closes #180 