### PR TITLE
Dyninst fix for BinaryEdit::getResolvedLibraryPath

### DIFF
--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -535,7 +535,7 @@ jobs:
       timeout-minutes: 10
       run:
         apt-get update &&
-        apt-get install -y build-essential m4 autoconf libtool python3-pip clang libomp-dev environment-modules gcc g++ mpich libmpich-dev &&
+        apt-get install -y build-essential m4 autoconf libtool python3-pip clang libomp-dev environment-modules gcc g++ mpich libmpich-dev texinfo &&
         python3 -m pip install --upgrade pip &&
         python3 -m pip install numpy &&
         python3 -m pip install perfetto &&
@@ -573,3 +573,4 @@ jobs:
           -DOMNITRACE_MAX_THREADS=32
           -DOMNITRACE_DISABLE_EXAMPLES="transpose;rccl"
           -DOMNITRACE_BUILD_NUMBER=${{ github.run_attempt }}
+          -DMPI_HEADERS_ALLOW_MPICH=ON


### PR DESCRIPTION
`/sbin/ldconfig -p` in Ubuntu 22.04 has line at the end similar to following:

```console
    ... etc. ...
    ld-linux-x86-64.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
    ... etc. ...
Cache generated by: ldconfig (Ubuntu GLIBC 2.35-0ubuntu3.1) stable release version 2.35
```

The previous implementation for reading the ld cache would overflow the stack when it tried to parse this line.

Note: the testing largely relies on pre-built Dyninst instances which are rebuilt nightly so this fix will not have an immediate effect.