### PR TITLE
roctracer: use multiple tracks for HIP streams

### DIFF
--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -551,6 +551,12 @@ configure_settings(bool _init)
                              "advanced");
 
     OMNITRACE_CONFIG_SETTING(
+        bool, "OMNITRACE_PERFETTO_ROCTRACER_PER_STREAM",
+        "Separate roctracer GPU side traces (copies, kernels) into separate "
+        "tracks based on the stream they're enqueued into",
+        true, "perfetto", "roctracer", "rocm", "advanced");
+
+    OMNITRACE_CONFIG_SETTING(
         std::string, "OMNITRACE_PERFETTO_FILL_POLICY",
         "Behavior when perfetto buffer is full. 'discard' will ignore new entries, "
         "'ring_buffer' will overwrite old entries",
@@ -1479,6 +1485,18 @@ get_use_roctracer()
 {
 #if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0
     static auto _v = get_config()->find("OMNITRACE_USE_ROCTRACER");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+#else
+    return false;
+#endif
+}
+
+bool
+get_perfetto_roctracer_per_stream()
+{
+#if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0 &&                   \
+    defined(OMNITRACE_USE_PERFETTO) && OMNITRACE_USE_PERFETTO > 0
+    static auto _v = get_config()->find("OMNITRACE_PERFETTO_ROCTRACER_PER_STREAM");
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 #else
     return false;

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -263,6 +263,9 @@ get_backend();
 std::string
 get_perfetto_output_filename();
 
+bool
+get_perfetto_roctracer_per_stream() OMNITRACE_HOT;
+
 int64_t
 get_critical_trace_count();
 

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -648,9 +648,10 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
     }
 
     static thread_local std::unordered_set<uintptr_t> seen_queues;
-    if(seen_queues.find(_queue) == seen_queues.end()) {
+    if(seen_queues.find(_queue) == seen_queues.end())
+    {
         const auto _queue_track = perfetto::Track(queue_uuid(_queue));
-        auto desc_ = _queue_track.Serialize();
+        auto       desc_        = _queue_track.Serialize();
 
         std::stringstream ss;
         ss << std::hex << _queue;
@@ -757,8 +758,8 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
                 critical_trace::add_hash_id(op_name), _depth);
         }
 
-        get_roctracer_cid_data(_tid).emplace(_corr_id,
-                                             cid_data{ _cid, _parent_cid, _depth, _queue });
+        get_roctracer_cid_data(_tid).emplace(
+            _corr_id, cid_data{ _cid, _parent_cid, _depth, _queue });
 
         hip_exec_activity_callbacks(_tid);
     }
@@ -950,7 +951,8 @@ hip_activity_callback(const char* begin, const char* end, void*)
 
             assert(_end_ns >= _beg_ns);
             // for some reason, this is necessary to make sure very last one ends
-            tracing::pop_perfetto_track(category::device_hip{}, "", _queue_track, _beg_ns);
+            tracing::pop_perfetto_track(category::device_hip{}, "", _queue_track,
+                                        _beg_ns);
 
             tracing::push_perfetto_track(
                 category::device_hip{}, _kernel_names.at(_name).c_str(), _queue_track,
@@ -959,7 +961,8 @@ hip_activity_callback(const char* begin, const char* end, void*)
                 _queid, "pid", record->process_id, "tid", _tid, "op",
                 _op_id_names.at(record->op));
 
-            tracing::pop_perfetto_track(category::device_hip{}, "", _queue_track, _end_ns);
+            tracing::pop_perfetto_track(category::device_hip{}, "", _queue_track,
+                                        _end_ns);
         }
 
         if(_critical_trace)

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -34,6 +34,8 @@
 #include <timemory/backends/threading.hpp>
 #include <timemory/utility/types.hpp>
 
+#include <perfetto.h>
+
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -118,7 +120,7 @@ get_roctracer_tid_data()
     return _v;
 }
 
-using cid_tuple_t = std::tuple<uint64_t, uint64_t, uint32_t>;
+using cid_tuple_t = std::tuple<uint64_t, uint64_t, uint32_t, uintptr_t>;
 struct cid_data : cid_tuple_t
 {
     using cid_tuple_t::cid_tuple_t;
@@ -128,10 +130,12 @@ struct cid_data : cid_tuple_t
     auto& cid() { return std::get<0>(*this); }
     auto& pcid() { return std::get<1>(*this); }
     auto& depth() { return std::get<2>(*this); }
+    auto& queue() { return std::get<3>(*this); }
 
     auto cid() const { return std::get<0>(*this); }
     auto pcid() const { return std::get<1>(*this); }
     auto depth() const { return std::get<2>(*this); }
+    auto queue() const { return std::get<3>(*this); }
 };
 
 auto&
@@ -508,6 +512,20 @@ roctx_api_callback(uint32_t domain, uint32_t cid, const void* callback_data,
     }
 }
 
+static std::size_t
+hash_combine(std::size_t i, std::size_t j)
+{
+    return i ^ (j + 0x9e3779b97f4a7c17ul + (i << 6) + (i >> 2));
+};
+
+static std::size_t
+queue_uuid(int queue_id)
+{
+    // SHA1 of "OMNITRACE_ROCTRACER_HIP_DEVICE_QUEUE"
+    static constexpr std::size_t hip_device_queue_namespace = 0x11c9d8a8894b428ul;
+    return hash_combine(hip_device_queue_namespace, queue_id);
+};
+
 // HIP API callback function
 void
 hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg)
@@ -629,6 +647,19 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         default: break;
     }
 
+    static thread_local std::unordered_set<uintptr_t> seen_queues;
+    if(seen_queues.find(_queue) == seen_queues.end()) {
+        const auto _queue_track = perfetto::Track(queue_uuid(_queue));
+        auto desc_ = _queue_track.Serialize();
+
+        std::stringstream ss;
+        ss << std::hex << _queue;
+        desc_.set_name("Stream 0x" + ss.str());
+        perfetto::TrackEvent::SetTrackDescriptor(_queue_track, desc_);
+
+        seen_queues.insert(_queue);
+    }
+
     auto& _device_id = get_current_device();
 
     if(data->phase == ACTIVITY_API_PHASE_ENTER)
@@ -727,7 +758,7 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         }
 
         get_roctracer_cid_data(_tid).emplace(_corr_id,
-                                             cid_data{ _cid, _parent_cid, _depth });
+                                             cid_data{ _cid, _parent_cid, _depth, _queue });
 
         hip_exec_activity_callbacks(_tid);
     }
@@ -735,7 +766,8 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
     {
         hip_exec_activity_callbacks(_tid);
 
-        std::tie(_cid, _parent_cid, _depth) = get_roctracer_cid_data(_tid).at(_corr_id);
+        std::tie(_cid, _parent_cid, _depth, std::ignore) =
+            get_roctracer_cid_data(_tid).at(_corr_id);
 
         if(get_use_perfetto())
         {
@@ -841,6 +873,7 @@ hip_activity_callback(const char* begin, const char* end, void*)
         uint64_t    _pcid           = 0;                     // parent corr_id
         int32_t     _devid          = record->device_id;     // device id
         int64_t     _queid          = record->queue_id;      // queue id
+        uintptr_t   _queue          = 0;                     // Host queue (stream)
         auto        _laps           = _indexes[_corr_id]++;  // see note #1
         const char* _name           = nullptr;
         bool        _found          = false;
@@ -864,7 +897,7 @@ hip_activity_callback(const char* begin, const char* end, void*)
         {
             auto& _cids = get_roctracer_cid_data(_tid);
             if(_cids.find(_corr_id) != _cids.end())
-                std::tie(_cid, _pcid, _depth) = _cids.at(_corr_id);
+                std::tie(_cid, _pcid, _depth, _queue) = _cids.at(_corr_id);
             else
             {
                 OMNITRACE_VERBOSE_F(3,
@@ -913,17 +946,20 @@ hip_activity_callback(const char* begin, const char* end, void*)
             if(_kernel_names.find(_name) == _kernel_names.end())
                 _kernel_names.emplace(_name, tim::demangle(_name));
 
+            const auto _queue_track = perfetto::Track(queue_uuid(_queue));
+
             assert(_end_ns >= _beg_ns);
-            tracing::push_perfetto_ts(
-                category::device_hip{}, _kernel_names.at(_name).c_str(), _beg_ns,
-                perfetto::Flow::ProcessScoped(_cid), "begin_ns", _beg_ns, "corr_id",
-                record->correlation_id, "device", _devid, "queue", _queid, "pid",
-                record->process_id, "tid", _tid, "op", _op_id_names.at(record->op));
-            tracing::pop_perfetto_ts(category::device_hip{}, "", _end_ns, "end_ns",
-                                     _end_ns);
             // for some reason, this is necessary to make sure very last one ends
-            tracing::pop_perfetto_ts(category::device_hip{}, "", _end_ns, "end_ns",
-                                     _end_ns);
+            tracing::pop_perfetto_track(category::device_hip{}, "", _queue_track, _beg_ns);
+
+            tracing::push_perfetto_track(
+                category::device_hip{}, _kernel_names.at(_name).c_str(), _queue_track,
+                _beg_ns, perfetto::TerminatingFlow::ProcessScoped(_cid), "begin_ns",
+                _beg_ns, "corr_id", record->correlation_id, "device", _devid, "queue",
+                _queid, "pid", record->process_id, "tid", _tid, "op",
+                _op_id_names.at(record->op));
+
+            tracing::pop_perfetto_track(category::device_hip{}, "", _queue_track, _end_ns);
         }
 
         if(_critical_trace)

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -647,18 +647,21 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
         default: break;
     }
 
-    static thread_local std::unordered_set<uintptr_t> seen_queues;
-    if(seen_queues.find(_queue) == seen_queues.end())
+    if(get_perfetto_roctracer_per_stream())
     {
-        const auto _queue_track = perfetto::Track(queue_uuid(_queue));
-        auto       desc_        = _queue_track.Serialize();
+        static thread_local std::unordered_set<uintptr_t> seen_queues;
+        if(seen_queues.find(_queue) == seen_queues.end())
+        {
+            const auto _queue_track = perfetto::Track(queue_uuid(_queue));
+            auto       desc_        = _queue_track.Serialize();
 
-        std::stringstream ss;
-        ss << std::hex << _queue;
-        desc_.set_name("Stream 0x" + ss.str());
-        perfetto::TrackEvent::SetTrackDescriptor(_queue_track, desc_);
+            std::stringstream ss;
+            ss << std::hex << _queue;
+            desc_.set_name("Stream 0x" + ss.str());
+            perfetto::TrackEvent::SetTrackDescriptor(_queue_track, desc_);
 
-        seen_queues.insert(_queue);
+            seen_queues.insert(_queue);
+        }
     }
 
     auto& _device_id = get_current_device();
@@ -947,7 +950,9 @@ hip_activity_callback(const char* begin, const char* end, void*)
             if(_kernel_names.find(_name) == _kernel_names.end())
                 _kernel_names.emplace(_name, tim::demangle(_name));
 
-            const auto _queue_track = perfetto::Track(queue_uuid(_queue));
+            const auto _queue_track = get_perfetto_roctracer_per_stream()
+                                          ? perfetto::Track(queue_uuid(_queue))
+                                          : perfetto::ThreadTrack::Current();
 
             assert(_end_ns >= _beg_ns);
             // for some reason, this is necessary to make sure very last one ends

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -516,7 +516,7 @@ static std::size_t
 hash_combine(std::size_t i, std::size_t j)
 {
     return i ^ (j + 0x9e3779b97f4a7c17ul + (i << 6) + (i >> 2));
-};
+}
 
 static std::size_t
 queue_uuid(int queue_id)
@@ -524,7 +524,7 @@ queue_uuid(int queue_id)
     // SHA1 of "OMNITRACE_ROCTRACER_HIP_DEVICE_QUEUE"
     static constexpr std::size_t hip_device_queue_namespace = 0x11c9d8a8894b428ul;
     return hash_combine(hip_device_queue_namespace, queue_id);
-};
+}
 
 // HIP API callback function
 void

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -307,7 +307,8 @@ pop_perfetto_ts(CategoryT, const char*, uint64_t _ts, Args&&... args)
 
 template <typename CategoryT, typename... Args>
 inline void
-push_perfetto_track(CategoryT, const std::string& name, perfetto::Track _track, uint64_t _ts, Args&&... args)
+push_perfetto_track(CategoryT, const std::string& name, perfetto::Track _track,
+                    uint64_t _ts, Args&&... args)
 {
     TRACE_EVENT_BEGIN(
         trait::name<CategoryT>::value, nullptr, _track, _ts, std::forward<Args>(args)...,
@@ -316,9 +317,11 @@ push_perfetto_track(CategoryT, const std::string& name, perfetto::Track _track, 
 
 template <typename CategoryT, typename... Args>
 inline void
-pop_perfetto_track(CategoryT, const char*, perfetto::Track _track, uint64_t _ts, Args&&... args)
+pop_perfetto_track(CategoryT, const char*, perfetto::Track _track, uint64_t _ts,
+                   Args&&... args)
 {
-    TRACE_EVENT_END(trait::name<CategoryT>::value, _track, _ts, std::forward<Args>(args)...);
+    TRACE_EVENT_END(trait::name<CategoryT>::value, _track, _ts,
+                    std::forward<Args>(args)...);
 }
 
 }  // namespace tracing

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -35,6 +35,8 @@
 
 #include <timemory/components/timing/backends.hpp>
 
+#include <perfetto.h>
+
 #include <type_traits>
 
 namespace omnitrace
@@ -302,5 +304,22 @@ pop_perfetto_ts(CategoryT, const char*, uint64_t _ts, Args&&... args)
 {
     TRACE_EVENT_END(trait::name<CategoryT>::value, _ts, std::forward<Args>(args)...);
 }
+
+template <typename CategoryT, typename... Args>
+inline void
+push_perfetto_track(CategoryT, const std::string& name, perfetto::Track _track, uint64_t _ts, Args&&... args)
+{
+    TRACE_EVENT_BEGIN(
+        trait::name<CategoryT>::value, nullptr, _track, _ts, std::forward<Args>(args)...,
+        [&name](perfetto::EventContext ctx) { ctx.event()->set_name(name); });
+}
+
+template <typename CategoryT, typename... Args>
+inline void
+pop_perfetto_track(CategoryT, const char*, perfetto::Track _track, uint64_t _ts, Args&&... args)
+{
+    TRACE_EVENT_END(trait::name<CategoryT>::value, _track, _ts, std::forward<Args>(args)...);
+}
+
 }  // namespace tracing
 }  // namespace omnitrace


### PR DESCRIPTION
Use different perfetto tracks for each stream, and set the name of these tracks to the stream pointer values. Setting the name like this matches the args in the API traces.
This fixes overlapping work on multiple streams appearing as a call stack.

Here's a screenshot of the results:
![out](https://user-images.githubusercontent.com/8176760/201084339-e4cd8a4e-f813-4d71-93b8-29e90818eb85.png)

I would like to add an option to disable the new behaviour, because some applications might create a large number of streams which would obscure the traces. The environment variable and option parsing parts I don't yet fully understand so therefore Draft, and I would appreciate some hints for that.
