### PR TITLE
Improve sampling allocator

### DIFF
--- a/source/bin/omnitrace/omnitrace.cpp
+++ b/source/bin/omnitrace/omnitrace.cpp
@@ -2197,18 +2197,18 @@ main(int argc, char** argv)
             verbprintf(0, "Consider instrumenting the relevant libraries...\n");
             verbprintf(0, "\n");
 
-            using TIMEMORY_PIPE = tim::popen::TIMEMORY_PIPE;
+            auto cmdv_envp = std::array<char*, 2>{};
+            cmdv_envp.fill(nullptr);
+            cmdv_envp.at(0) = strdup("LD_TRACE_LOADED_OBJECTS=1");
+            auto ldd        = tim::popen::popen(cmdv0.c_str(), nullptr, cmdv_envp.data());
+            auto linked_libs = tim::popen::read_ldd_fork(ldd);
+            auto perr        = tim::popen::pclose(ldd);
+            for(auto& itr : cmdv_envp)
+                ::free(itr);
 
-            tim::set_env("LD_TRACE_LOADED_OBJECTS", "1", 1);
-            TIMEMORY_PIPE* ldd = tim::popen::popen(cmdv0.c_str());
-            tim::set_env("LD_TRACE_LOADED_OBJECTS", "0", 1);
-
-            strvec_t linked_libraries = tim::popen::read_ldd_fork(ldd);
-
-            auto perr = tim::popen::pclose(ldd);
             if(perr != 0) perror("Error in omnitrace_fork");
 
-            for(const auto& itr : linked_libraries)
+            for(const auto& itr : linked_libs)
                 verbprintf(0, "\t%s\n", itr.c_str());
 
             verbprintf(0, "\n");

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -302,6 +302,12 @@ get_sampling_real_tids();
 bool
 get_sampling_include_inlines();
 
+size_t
+get_num_threads_hint();
+
+size_t
+get_sampling_allocator_size();
+
 double
 get_process_sampling_freq();
 


### PR DESCRIPTION
- dynamic sampler is constructed with a shared pointer to an allocator instance
- allocator handles multiple samplers
  - eliminates need for every per-thread dynamic sampler to start background allocator thread
  - reduces number of background threads
  - supports starting all background allocator threads during initialization
- new advanced configuration variable `OMNITRACE_SAMPLING_ALLOCATOR_SIZE`
  - number of sampler instances handled by allocator
- new advanced configuration variable `OMNITRACE_NUM_THREADS_HINT`
  - hint for number of threads created by app, when set appropriately, sampling will start all required allocator threads during initialization
- timemory submodule was updated with various fixes for its own tests
