### PR TITLE
roctracer: device and stream tracks

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -161,16 +161,11 @@ jobs:
           echo "CI_SCRIPT_ARGS=--rocm +python" >> $GITHUB_ENV
 
       - name: Build Base Container
-        timeout-minutes: 20
-        uses: nick-fields/retry@v2
-        with:
-          retry_wait_seconds: 120
-          timeout_minutes: 20
-          max_attempts: 5
-          command: |
-            pushd docker
-            ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }}
-            popd
+        timeout-minutes: 30
+        run: |
+          pushd docker
+          ./build-docker.sh --distro ${{ matrix.os-distro }} --versions ${{ matrix.os-version }} --rocm-versions ${{ matrix.rocm-version }}
+          popd
 
       - name: Build Release
         timeout-minutes: 150

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   OMNITRACE_VERBOSE: 1
   OMNITRACE_CI: ON
+  OMNITRACE_TMPDIR: "%env{PWD}%/testing-tmp"
 
 jobs:
   opensuse:

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -37,11 +37,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           for i in 6 7 8 9 10; do /opt/conda/envs/py3.${i}/bin/python -m pip install numpy perfetto dataclasses; done

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -23,6 +23,7 @@ env:
   OMNITRACE_VERBOSE: 1
   OMNITRACE_CI: ON
   GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
+  OMNITRACE_TMPDIR: "%env{PWD}%/testing-tmp"
 
 jobs:
   ubuntu-bionic:

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - name: Patch Git
-      timeout-minutes: 10
+      timeout-minutes: 25
       run: |
         apt-get update
         apt-get install -y software-properties-common
@@ -51,11 +51,11 @@ jobs:
         submodules: recursive
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           apt-get update &&

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   OMNITRACE_VERBOSE: 1
   OMNITRACE_CI: ON
+  OMNITRACE_TMPDIR: "%env{PWD}%/testing-tmp"
 
 jobs:
   ubuntu-focal-external:

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -67,11 +67,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           apt-get update &&
@@ -244,11 +244,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           apt-get update &&
@@ -408,11 +408,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           sudo apt-get update &&
@@ -555,11 +555,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           apt-get update &&

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   OMNITRACE_VERBOSE: 1
   OMNITRACE_CI: ON
+  OMNITRACE_TMPDIR: "%env{PWD}%/testing-tmp"
 
 jobs:
   ubuntu-jammy-external:

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -70,11 +70,11 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         command: |
           apt-get update &&
@@ -87,12 +87,12 @@ jobs:
           for i in 6 7 8 9 10; do /opt/conda/envs/py3.${i}/bin/python -m pip install numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages
-      timeout-minutes: 10
+      timeout-minutes: 25
       if: ${{ matrix.rocm-version != '0.0' }}
       uses: nick-fields/retry@v2
       with:
         retry_wait_seconds: 30
-        timeout_minutes: 10
+        timeout_minutes: 25
         max_attempts: 5
         shell: bash
         command: |

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -7,6 +7,7 @@
 : ${PYTHON_VERSIONS:="6 7 8 9 10"}
 : ${BUILD_CI:=""}
 : ${PUSH:=0}
+: ${RETRY:=3}
 
 set -e
 
@@ -32,7 +33,9 @@ usage()
     print_default_option versions "[VERSION] [VERSION...]" "Ubuntu or OpenSUSE release" "${VERSIONS}"
     print_default_option rocm-versions "[VERSION] [VERSION...]" "ROCm versions" "${ROCM_VERSIONS}"
     print_default_option python-versions "[VERSION] [VERSION...]" "Python 3 minor releases" "${PYTHON_VERSIONS}"
-    print_default_option user "[USERNAME]" "DockerHub username" "${USER}"
+    print_default_option "user -u" "[USERNAME]" "DockerHub username" "${USER}"
+    print_default_option "retry -r" "[N]" "Number of attempts to build (to account for network errors" "${RETRY}"
+    print_default_option push "" "Push the image to Dockerhub" ""
     #print_default_option lto "[on|off]" "Enable LTO" "${LTO}"
 }
 
@@ -46,7 +49,31 @@ send-error()
 verbose-run()
 {
     echo -e "\n### Executing \"${@}\"... ###\n"
-    eval $@
+    eval "${@}"
+}
+
+verbose-build()
+{
+    echo -e "\n### Executing \"${@}\" a maximum of ${RETRY} times... ###\n"
+    for i in $(seq 1 1 ${RETRY})
+    do
+        set +e
+        eval "${@}"
+        local RETC=$?
+        set -e
+        if [ "${RETC}" -eq 0 ]; then
+            break
+        else
+            echo -en "\n### Command failed with error code ${RETC}... "
+            if [ "${i}" -ne "${RETRY}" ]; then
+                echo -e "Retrying... ###\n"
+                sleep 3
+            else
+                echo -e "Exiting... ###\n"
+                exit ${RETC}
+            fi
+        fi
+    done
 }
 
 reset-last()
@@ -91,6 +118,11 @@ do
             ;;
         --push)
             PUSH=1
+            ;;
+        --retry|-r)
+            shift
+            RETRY=${1}
+            reset-last
             ;;
         "--*")
             send-error "Unsupported argument at position $((${n} + 1)) :: ${1}"
@@ -149,7 +181,7 @@ do
                 *)
                     ;;
             esac
-            verbose-run docker build . -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg ROCM_REPO_VERSION=${ROCM_REPO_VERSION} --build-arg ROCM_REPO_DIST=${ROCM_REPO_DIST} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
+            verbose-build docker build . -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg ROCM_REPO_VERSION=${ROCM_REPO_VERSION} --build-arg ROCM_REPO_DIST=${ROCM_REPO_DIST} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
         elif [ "${DISTRO}" = "centos" ]; then
             case "${VERSION}" in
                 7)
@@ -192,7 +224,7 @@ do
                     send-error "Unsupported combination :: ${DISTRO}-${VERSION} + ROCm ${ROCM_VERSION}"
                     ;;
             esac
-            verbose-run docker build . -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg TOOLSET_VERSION=${TOOLSET_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
+            verbose-build docker build . -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg TOOLSET_VERSION=${TOOLSET_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
         elif [ "${DISTRO}" = "opensuse" ]; then
             case "${VERSION}" in
                 15.*)
@@ -225,7 +257,7 @@ do
                     send-error "Unsupported combination :: ${DISTRO}-${VERSION} + ROCm ${ROCM_VERSION}"
                 ;;
             esac
-            verbose-run docker build . -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO_IMAGE} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
+            verbose-build docker build . -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO_IMAGE} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
         fi
         if [ "${PUSH}" -ne 0 ]; then
             docker push ${CONTAINER}

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -577,6 +577,12 @@ configure_settings(bool _init)
                              "advanced");
 
     OMNITRACE_CONFIG_SETTING(
+        bool, "OMNITRACE_PERFETTO_ROCTRACER_PER_STREAM",
+        "Separate roctracer GPU side traces (copies, kernels) into separate "
+        "tracks based on the stream they're enqueued into",
+        true, "perfetto", "roctracer", "rocm", "advanced");
+
+    OMNITRACE_CONFIG_SETTING(
         std::string, "OMNITRACE_PERFETTO_FILL_POLICY",
         "Behavior when perfetto buffer is full. 'discard' will ignore new entries, "
         "'ring_buffer' will overwrite old entries",
@@ -1512,6 +1518,18 @@ get_use_roctracer()
 {
 #if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0
     static auto _v = get_config()->find("OMNITRACE_USE_ROCTRACER");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+#else
+    return false;
+#endif
+}
+
+bool
+get_perfetto_roctracer_per_stream()
+{
+#if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0 &&                   \
+    defined(OMNITRACE_USE_PERFETTO) && OMNITRACE_USE_PERFETTO > 0
+    static auto _v = get_config()->find("OMNITRACE_PERFETTO_ROCTRACER_PER_STREAM");
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 #else
     return false;

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -1527,8 +1527,7 @@ get_use_roctracer()
 bool
 get_perfetto_roctracer_per_stream()
 {
-#if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0 &&                   \
-    defined(OMNITRACE_USE_PERFETTO) && OMNITRACE_USE_PERFETTO > 0
+#if defined(OMNITRACE_USE_ROCTRACER) && OMNITRACE_USE_ROCTRACER > 0
     static auto _v = get_config()->find("OMNITRACE_PERFETTO_ROCTRACER_PER_STREAM");
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 #else

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -266,6 +266,9 @@ get_backend();
 std::string
 get_perfetto_output_filename();
 
+bool
+get_perfetto_roctracer_per_stream() OMNITRACE_HOT;
+
 int64_t
 get_critical_trace_count();
 

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -953,8 +953,7 @@ hip_activity_callback(const char* begin, const char* end, void* arg)
             assert(_end_ns >= _beg_ns);
             tracing::push_perfetto_track(
                 category::device_hip{}, _kernel_names.at(_name).c_str(), _track, _beg_ns,
-                perfetto::TerminatingFlow::ProcessScoped(_cid),
-                [&](perfetto::EventContext ctx) {
+                perfetto::Flow::ProcessScoped(_cid), [&](perfetto::EventContext ctx) {
                     if(config::get_perfetto_annotations())
                     {
                         tracing::add_perfetto_annotation(ctx, "begin_ns", _beg_ns);
@@ -1001,6 +1000,9 @@ hip_activity_callback(const char* begin, const char* end, void* arg)
             _async_ops->emplace_back(std::move(_func));
         }
     }
+
+    // ensures that all the updates are written
+    if(get_use_perfetto()) ::perfetto::TrackEvent::Flush();
 }
 
 bool&

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -540,7 +540,7 @@ static std::size_t
 hash_combine(std::size_t i, std::size_t j)
 {
     return i ^ (j + 0x9e3779b97f4a7c17ul + (i << 6) + (i >> 2));
-};
+}
 
 static std::size_t
 queue_uuid(int queue_id)
@@ -548,7 +548,7 @@ queue_uuid(int queue_id)
     // SHA1 of "OMNITRACE_ROCTRACER_HIP_DEVICE_QUEUE"
     static constexpr std::size_t hip_device_queue_namespace = 0x11c9d8a8894b428ul;
     return hash_combine(hip_device_queue_namespace, queue_id);
-};
+}
 
 // HIP API callback function
 void

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -672,9 +672,10 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
     }
 
     static thread_local std::unordered_set<uintptr_t> seen_queues;
-    if(seen_queues.find(_queue) == seen_queues.end()) {
+    if(seen_queues.find(_queue) == seen_queues.end())
+    {
         const auto _queue_track = perfetto::Track(queue_uuid(_queue));
-        auto desc_ = _queue_track.Serialize();
+        auto       desc_        = _queue_track.Serialize();
 
         std::stringstream ss;
         ss << std::hex << _queue;
@@ -791,8 +792,8 @@ hip_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void*
                 critical_trace::add_hash_id(op_name), _depth);
         }
 
-        get_roctracer_cid_data(_tid).emplace(_corr_id,
-                                             cid_data{ _cid, _parent_cid, _depth, _queue });
+        get_roctracer_cid_data(_tid).emplace(
+            _corr_id, cid_data{ _cid, _parent_cid, _depth, _queue });
 
         hip_exec_activity_callbacks(_tid);
     }

--- a/source/lib/omnitrace/library/roctracer.hpp
+++ b/source/lib/omnitrace/library/roctracer.hpp
@@ -57,7 +57,7 @@ void
 hsa_api_callback(uint32_t domain, uint32_t cid, const void* callback_data, void* arg);
 
 void
-hsa_activity_callback(uint32_t op, activity_record_t* record, void* arg);
+hsa_activity_callback(uint32_t op, const activity_record_t* record, void* arg);
 
 void
 hip_exec_activity_callbacks(int64_t _tid);

--- a/source/lib/omnitrace/library/tracing.cpp
+++ b/source/lib/omnitrace/library/tracing.cpp
@@ -43,6 +43,13 @@ get_perfetto_session()
     return _v;
 }
 
+std::unordered_map<hash_value_t, std::string>&
+get_perfetto_track_uuids()
+{
+    static thread_local auto _v = std::unordered_map<hash_value_t, std::string>{};
+    return _v;
+}
+
 std::vector<std::function<void()>>&
 get_finalization_functions()
 {

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -38,6 +38,8 @@
 #include <timemory/hash/types.hpp>
 #include <timemory/mpl/type_traits.hpp>
 
+#include <perfetto.h>
+
 #include <type_traits>
 
 namespace omnitrace
@@ -292,5 +294,21 @@ pop_perfetto_ts(CategoryT, const char*, uint64_t _ts, Args&&... args)
 
     TRACE_EVENT_END(trait::name<CategoryT>::value, _ts, std::forward<Args>(args)...);
 }
+
+template <typename CategoryT, typename... Args>
+inline void
+push_perfetto_track(CategoryT, const char* name, perfetto::Track _track, uint64_t _ts, Args&&... args)
+{
+    TRACE_EVENT_BEGIN(trait::name<CategoryT>::value, perfetto::StaticString(name), _track,
+                      _ts, std::forward<Args>(args)...);
+}
+
+template <typename CategoryT, typename... Args>
+inline void
+pop_perfetto_track(CategoryT, const char*, perfetto::Track _track, uint64_t _ts, Args&&... args)
+{
+    TRACE_EVENT_END(trait::name<CategoryT>::value, _track, _ts, std::forward<Args>(args)...);
+}
+
 }  // namespace tracing
 }  // namespace omnitrace

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -38,21 +38,76 @@
 #include <timemory/hash/types.hpp>
 #include <timemory/mpl/type_traits.hpp>
 
-#include <perfetto.h>
-
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <ratio>
+#include <string>
 #include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace omnitrace
 {
 namespace tracing
 {
 using interval_data_instances = thread_data<std::vector<bool>>;
+using hash_value_t            = tim::hash_value_t;
 
 perfetto::TraceConfig&
 get_perfetto_config();
 
 std::unique_ptr<perfetto::TracingSession>&
 get_perfetto_session();
+
+template <typename CategoryT, typename... Args>
+auto
+get_perfetto_category_uuid(Args&&... _args)
+{
+    return tim::hash::get_combined_hash_id(
+        tim::hash::get_hash_id(JOIN('_', "omnitrace", trait::name<CategoryT>::value)),
+        std::forward<Args>(_args)...);
+}
+
+std::unordered_map<hash_value_t, std::string>&
+get_perfetto_track_uuids();
+
+template <typename CategoryT, typename TrackT = ::perfetto::Track, typename FuncT,
+          typename... Args>
+auto
+get_perfetto_track(CategoryT, FuncT&& _desc_generator, Args&&... _args)
+{
+    auto  _uuid = get_perfetto_category_uuid<CategoryT>(std::forward<Args>(_args)...);
+    auto& _track_uuids = get_perfetto_track_uuids();
+    if(_track_uuids.find(_uuid) == _track_uuids.end())
+    {
+        const auto _track = TrackT(_uuid);
+        auto       _desc  = _track.Serialize();
+
+        auto _name = std::forward<FuncT>(_desc_generator)(std::forward<Args>(_args)...);
+        _desc.set_name(_name);
+        ::perfetto::TrackEvent::SetTrackDescriptor(_track, _desc);
+
+        OMNITRACE_VERBOSE_F(4, "[%s] Created %s(%zu) with description: \"%s\"\n",
+                            trait::name<CategoryT>::value, demangle<TrackT>().c_str(),
+                            _uuid, _name.c_str());
+
+        _track_uuids.emplace(_uuid, _name);
+    }
+
+    // guard this with ppdefs in addition to runtime check to avoid
+    // overhead of generating string during releases
+#if defined(OMNITRACE_CI) && OMNITRACE_CI > 0
+    auto _name = std::forward<FuncT>(_desc_generator)(std::forward<Args>(_args)...);
+    OMNITRACE_CI_THROW(_track_uuids.at(_uuid) != _name,
+                       "Error! Multiple invocations of UUID %zu produced different "
+                       "descriptions: \"%s\" and \"%s\"\n",
+                       _uuid, _track_uuids.at(_uuid).c_str(), _name.c_str());
+#endif
+
+    return TrackT(_uuid);
+}
 
 std::vector<std::function<void()>>&
 get_finalization_functions();

--- a/source/lib/omnitrace/library/tracing.hpp
+++ b/source/lib/omnitrace/library/tracing.hpp
@@ -297,7 +297,8 @@ pop_perfetto_ts(CategoryT, const char*, uint64_t _ts, Args&&... args)
 
 template <typename CategoryT, typename... Args>
 inline void
-push_perfetto_track(CategoryT, const char* name, perfetto::Track _track, uint64_t _ts, Args&&... args)
+push_perfetto_track(CategoryT, const char* name, perfetto::Track _track, uint64_t _ts,
+                    Args&&... args)
 {
     TRACE_EVENT_BEGIN(trait::name<CategoryT>::value, perfetto::StaticString(name), _track,
                       _ts, std::forward<Args>(args)...);
@@ -305,9 +306,11 @@ push_perfetto_track(CategoryT, const char* name, perfetto::Track _track, uint64_
 
 template <typename CategoryT, typename... Args>
 inline void
-pop_perfetto_track(CategoryT, const char*, perfetto::Track _track, uint64_t _ts, Args&&... args)
+pop_perfetto_track(CategoryT, const char*, perfetto::Track _track, uint64_t _ts,
+                   Args&&... args)
 {
-    TRACE_EVENT_END(trait::name<CategoryT>::value, _track, _ts, std::forward<Args>(args)...);
+    TRACE_EVENT_END(trait::name<CategoryT>::value, _track, _ts,
+                    std::forward<Args>(args)...);
 }
 
 }  // namespace tracing


### PR DESCRIPTION
- Includes general idea behind #201
- Closes #208 
- New configuration variable `OMNITRACE_PERFETTO_ROCTRACER_PER_STREAM`
  - Default value is `ON`
  - Disabling this option will group all GPU activity per-device
- There is not config option for disabling per-device GPU activity
- Handle HSA OPS in ROCm 5.3
  - The changes in ROCm 5.3 were causing HSA ops to get discarded
- Default for `OMNITRACE_ROCTRACER_DISCARD_INVALID` environment variable is now zero
  - i.e. default behavior is to flip begin and end timestamps when begin > end