### PR TITLE
Perfetto updates

### DIFF
--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -34,7 +34,7 @@ usage()
     print_default_option rocm-versions "[VERSION] [VERSION...]" "ROCm versions" "${ROCM_VERSIONS}"
     print_default_option python-versions "[VERSION] [VERSION...]" "Python 3 minor releases" "${PYTHON_VERSIONS}"
     print_default_option "user -u" "[USERNAME]" "DockerHub username" "${USER}"
-    print_default_option "retry -r" "[N]" "Number of attempts to build (to account for network errors" "${RETRY}"
+    print_default_option "retry -r" "[N]" "Number of attempts to build (to account for network errors)" "${RETRY}"
     print_default_option push "" "Push the image to Dockerhub" ""
     #print_default_option lto "[on|off]" "Enable LTO" "${LTO}"
 }

--- a/source/lib/omnitrace/library/components/backtrace_metrics.cpp
+++ b/source/lib/omnitrace/library/components/backtrace_metrics.cpp
@@ -137,6 +137,13 @@ backtrace_metrics::description()
     return "Records sampling data";
 }
 
+std::vector<std::string>
+backtrace_metrics::get_hw_counter_labels(int64_t _tid)
+{
+    auto& _v = get_papi_labels(_tid);
+    return (_v) ? *_v : std::vector<std::string>{};
+}
+
 void
 backtrace_metrics::start()
 {}
@@ -192,10 +199,8 @@ backtrace_metrics::configure(bool _setup, int64_t _tid)
             OMNITRACE_DEBUG("HW COUNTER: starting...\n");
             if(get_papi_vector(_tid))
             {
-                using common_type_t = typename hw_counters::common_type;
                 get_papi_vector(_tid)->start();
-                *get_papi_labels(_tid) =
-                    comp::papi_common<common_type_t>::get_config()->labels;
+                *get_papi_labels(_tid) = get_papi_vector(_tid)->get_config()->labels;
             }
         }
     }

--- a/source/lib/omnitrace/library/components/backtrace_metrics.hpp
+++ b/source/lib/omnitrace/library/components/backtrace_metrics.hpp
@@ -71,9 +71,10 @@ struct backtrace_metrics
     backtrace_metrics& operator=(const backtrace_metrics&) = default;
     backtrace_metrics& operator=(backtrace_metrics&&) noexcept = default;
 
-    static void configure(bool, int64_t _tid = threading::get_id());
-    static void init_perfetto(int64_t _tid);
-    static void fini_perfetto(int64_t _tid);
+    static void                     configure(bool, int64_t _tid = threading::get_id());
+    static void                     init_perfetto(int64_t _tid);
+    static void                     fini_perfetto(int64_t _tid);
+    static std::vector<std::string> get_hw_counter_labels(int64_t);
 
     static void start();
     static void stop();

--- a/source/lib/omnitrace/library/components/exit_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/exit_gotcha.cpp
@@ -50,6 +50,8 @@ exit_gotcha::configure()
 
 namespace
 {
+auto _exit_info = exit_gotcha::exit_info{};
+
 template <typename FuncT, typename... Args>
 void
 invoke_exit_gotcha(const exit_gotcha::gotcha_data& _data, FuncT _func, Args... _args)
@@ -87,6 +89,7 @@ invoke_exit_gotcha(const exit_gotcha::gotcha_data& _data, FuncT _func, Args... _
 void
 exit_gotcha::operator()(const gotcha_data& _data, exit_func_t _func, int _ec) const
 {
+    _exit_info = { true, _data.tool_id.find("quick") != std::string::npos, _ec };
     invoke_exit_gotcha(_data, _func, _ec);
 }
 
@@ -95,6 +98,12 @@ void
 exit_gotcha::operator()(const gotcha_data& _data, abort_func_t _func) const
 {
     invoke_exit_gotcha(_data, _func);
+}
+
+exit_gotcha::exit_info
+exit_gotcha::get_exit_info()
+{
+    return _exit_info;
 }
 }  // namespace component
 }  // namespace omnitrace

--- a/source/lib/omnitrace/library/components/exit_gotcha.hpp
+++ b/source/lib/omnitrace/library/components/exit_gotcha.hpp
@@ -60,6 +60,14 @@ struct exit_gotcha : tim::component::base<exit_gotcha, void>
     void operator()(const gotcha_data&, exit_func_t, int) const;
     // abort
     void operator()(const gotcha_data&, abort_func_t) const;
+
+    struct exit_info
+    {
+        bool is_known  = false;
+        bool is_quick  = false;
+        int  exit_code = EXIT_SUCCESS;
+    };
+    static exit_info get_exit_info();
 };
 }  // namespace component
 

--- a/source/lib/omnitrace/library/critical_trace.hpp
+++ b/source/lib/omnitrace/library/critical_trace.hpp
@@ -25,6 +25,7 @@
 #include "library/common.hpp"
 #include "library/config.hpp"
 #include "library/defines.hpp"
+#include "library/perfetto.hpp"
 #include "library/runtime.hpp"
 #include "library/thread_data.hpp"
 
@@ -245,7 +246,7 @@ struct call_chain : private std::vector<entry>
     }
 
     template <Device DevT>
-    void generate_perfetto(std::set<entry>& _used) const;
+    void generate_perfetto(::perfetto::Track, std::set<entry>& _used) const;
 
     template <bool BoolV = true, typename FuncT>
     bool query(FuncT&&) const;
@@ -366,3 +367,20 @@ add_critical_trace(int32_t _targ_tid, size_t _cpu_cid, size_t _gpu_cid,
                             _ts_val, _devid, _queue, _hash, _depth, _prio, num_mutexes);
 }
 }  // namespace omnitrace
+
+namespace std
+{
+inline std::string
+to_string(::omnitrace::critical_trace::Device _v)
+{
+    using Device = ::omnitrace::critical_trace::Device;
+    switch(_v)
+    {
+        case Device::NONE: return std::string{};
+        case Device::CPU: return std::string{ "CPU" };
+        case Device::GPU: return std::string{ "GPU" };
+        case Device::ANY: return std::string{ "CPU + GPU" };
+    }
+    return std::string{ "Unknown Device" };
+}
+}  // namespace std

--- a/source/lib/omnitrace/library/ompt.cpp
+++ b/source/lib/omnitrace/library/ompt.cpp
@@ -129,7 +129,7 @@ tool_initialize(ompt_function_lookup_t lookup, int initial_device_num,
             lookup, initial_device_num, tool_data);
     }
     return 1;  // success
-};
+}
 
 void
 tool_finalize(ompt_data_t*)

--- a/source/lib/omnitrace/library/ompt.cpp
+++ b/source/lib/omnitrace/library/ompt.cpp
@@ -60,6 +60,7 @@ namespace
 std::unique_ptr<ompt_bundle_t> f_bundle = {};
 bool _init_toolset_off = (trait::runtime_enabled<ompt_toolset_t>::set(false),
                           trait::runtime_enabled<ompt_context_t>::set(false), true);
+tim::ompt::finalize_tool_func_t f_finalize = nullptr;
 }  // namespace
 
 void
@@ -79,6 +80,9 @@ setup()
 void
 shutdown()
 {
+    static bool _protect = false;
+    if(_protect) return;
+    _protect = true;
     if(f_bundle)
     {
         f_bundle->stop();
@@ -86,21 +90,26 @@ shutdown()
         trait::runtime_enabled<ompt_toolset_t>::set(false);
         trait::runtime_enabled<ompt_context_t>::set(false);
         comp::user_ompt_bundle::reset();
+        // call the OMPT finalize callback
+        if(f_finalize) (*f_finalize)();
     }
     f_bundle.reset();
+    _protect = false;
 }
-}  // namespace ompt
-}  // namespace omnitrace
 
-extern "C" ompt_start_tool_result_t*
-ompt_start_tool(unsigned int omp_version, const char* runtime_version)
+namespace
 {
-    TIMEMORY_PRINTF(stderr, "OpenMP version: %u, runtime version: %s\n", omp_version,
-                    runtime_version);
+bool&
+use_tool()
+{
+    static bool _v = false;
+    return _v;
+}
 
-    OMNITRACE_METADATA("OMP_VERSION", omp_version);
-    OMNITRACE_METADATA("OMP_RUNTIME_VERSION", runtime_version);
-
+int
+tool_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                ompt_data_t* tool_data)
+{
     if(!omnitrace::settings_are_configured())
     {
         OMNITRACE_BASIC_WARNING(
@@ -111,25 +120,38 @@ ompt_start_tool(unsigned int omp_version, const char* runtime_version)
         omnitrace::configure_settings();
     }
 
-    static bool _use_ompt       = omnitrace::config::get_use_ompt();
-    static auto ompt_initialize = [](ompt_function_lookup_t lookup,
-                                     int                    initial_device_num,
-                                     ompt_data_t*           tool_data) -> int {
-        _use_ompt = omnitrace::config::get_use_ompt();
-        if(_use_ompt)
-        {
-            TIMEMORY_PRINTF(stderr, "OpenMP-tools configuring for initial device %i\n\n",
-                            initial_device_num);
-            tim::ompt::configure<TIMEMORY_OMPT_API_TAG>(lookup, initial_device_num,
-                                                        tool_data);
-        }
-        return 1;  // success
-    };
+    use_tool() = omnitrace::config::get_use_ompt();
+    if(use_tool())
+    {
+        TIMEMORY_PRINTF(stderr, "OpenMP-tools configuring for initial device %i\n\n",
+                        initial_device_num);
+        f_finalize = tim::ompt::configure<TIMEMORY_OMPT_API_TAG>(
+            lookup, initial_device_num, tool_data);
+    }
+    return 1;  // success
+};
 
-    static auto ompt_finalize = [](ompt_data_t*) {};
+void
+tool_finalize(ompt_data_t*)
+{
+    shutdown();
+}
+}  // namespace
+}  // namespace ompt
+}  // namespace omnitrace
 
-    static auto data = ompt_start_tool_result_t{ ompt_initialize, ompt_finalize, { 0 } };
-    return (ompt_start_tool_result_t*) &data;
+extern "C" ompt_start_tool_result_t*
+ompt_start_tool(unsigned int omp_version, const char* runtime_version)
+{
+    OMNITRACE_BASIC_VERBOSE_F(0, "OpenMP version: %u, runtime version: %s\n", omp_version,
+                              runtime_version);
+    OMNITRACE_METADATA("OMP_VERSION", omp_version);
+    OMNITRACE_METADATA("OMP_RUNTIME_VERSION", runtime_version);
+
+    static auto* data = new ompt_start_tool_result_t{ &omnitrace::ompt::tool_initialize,
+                                                      &omnitrace::ompt::tool_finalize,
+                                                      { 0 } };
+    return data;
 }
 
 #else


### PR DESCRIPTION
- critical trace update
  - use ::perfetto::Track instead of threads to create rows
  - refactor call_chain::generate_perfetto
- fix backtrace_metrics for perfetto
  - get_papi_labels is now properly populated
  - closes #210 
- refactor sampling::post_process_perfetto
  - include HW counter delta in sample debug annotations
  - reduce the amount debug annotation data stored in the call-stack
    - if the data is common to the entire stack, it is only annotated in the first and the last call-stack entry