### PR TITLE
rocm: Fix compilation with rocm >= 5.3.1

### DIFF
--- a/source/lib/omnitrace/library/rocm.cpp
+++ b/source/lib/omnitrace/library/rocm.cpp
@@ -237,13 +237,20 @@ extern "C"
                             hsa_activity_callback),
                         nullptr, output_prefix
                     };
-#else
+#elseif OMNITRACE_HIP_VERSION < 50301
                     hsa_ops_properties_t ops_properties;
                     ops_properties.table = table;
                     ops_properties.reserved1[0] =
                         reinterpret_cast<void*>(&hsa_activity_callback);
                     ops_properties.reserved1[1] = nullptr;
                     ops_properties.reserved1[2] = nullptr;
+#else
+                    hsa_ops_properties_t ops_properties {
+                        table,
+                        reinterpret_cast<void*>(&hsa_activity_callback),
+                        nullptr,
+                        nullptr
+                    };
 #endif
                     roctracer_set_properties(ACTIVITY_DOMAIN_HSA_OPS, &ops_properties);
 

--- a/source/lib/omnitrace/library/rocm.cpp
+++ b/source/lib/omnitrace/library/rocm.cpp
@@ -237,7 +237,7 @@ extern "C"
                             hsa_activity_callback),
                         nullptr, output_prefix
                     };
-#    elseif OMNITRACE_HIP_VERSION < 50301
+#elif OMNITRACE_HIP_VERSION < 50301
                     hsa_ops_properties_t ops_properties;
                     ops_properties.table = table;
                     ops_properties.reserved1[0] =

--- a/source/lib/omnitrace/library/rocm.cpp
+++ b/source/lib/omnitrace/library/rocm.cpp
@@ -237,7 +237,7 @@ extern "C"
                             hsa_activity_callback),
                         nullptr, output_prefix
                     };
-#elseif OMNITRACE_HIP_VERSION < 50301
+#    elseif OMNITRACE_HIP_VERSION < 50301
                     hsa_ops_properties_t ops_properties;
                     ops_properties.table = table;
                     ops_properties.reserved1[0] =
@@ -245,10 +245,8 @@ extern "C"
                     ops_properties.reserved1[1] = nullptr;
                     ops_properties.reserved1[2] = nullptr;
 #else
-                    hsa_ops_properties_t ops_properties {
-                        table,
-                        reinterpret_cast<void*>(&hsa_activity_callback),
-                        nullptr,
+                    hsa_ops_properties_t ops_properties{
+                        table, reinterpret_cast<void*>(&hsa_activity_callback), nullptr,
                         nullptr
                     };
 #endif


### PR DESCRIPTION
Add another version checked initialiation, because: [roctracer has changed `hsa_ops_properties_t` again in 5.3.1][hsa_ops_properties_t]

[hsa_ops_properties_t]: https://github.com/ROCm-Developer-Tools/roctracer/compare/rocm-5.3.0...rocm-5.3.1#diff-42ffacd4e7f57213868dcd96aeb5c0d47d91d2a1121ba8d67f46caa267c1818cL41

Fixes: #213 