### PR TITLE
omnitrace-install.py

### DIFF
--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -28,11 +28,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Generate generic installer script
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install -y cmake
+          cmake -D OUTPUT_DIR=${PWD} -P scripts/write-omnitrace-install.cmake
       - name: Generate Release
         uses: softprops/action-gh-release@v1
         with:
-          draft: True
+          draft: False
           generate_release_notes: True
+          fail_on_unmatched_files: True
+          files: |
+            omnitrace-install.py
 
   release-docs:
     if: github.repository == 'AMDResearch/omnitrace' && (startsWith(github.ref, 'refs/tags/') || contains(github.ref, 'releases/'))

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@
 /.cache
 /.clangd
 /compile_commands.json
+/omnitrace-install.py
+/scripts/omnitrace-install.py

--- a/cmake/Templates/omnitrace-install.py.in
+++ b/cmake/Templates/omnitrace-install.py.in
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import stat
+import argparse
+import tempfile
+import subprocess as sp
+from urllib import request
+from urllib.error import HTTPError
+
+omnitrace_version = "@OMNITRACE_VERSION@"
+_rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
+_rocm_version = None
+
+
+def get_rocm_version(rocm_hint):
+    global _rocm_path
+    global _rocm_version
+
+    if rocm_hint is not None and rocm_hint is not True:
+        if rocm_hint.replace(".", "0").isnumeric():
+            _rocm_version = rocm_hint
+        else:
+            _rocm_path = rocm_hint
+
+    def _parse_version(_v):
+        return re.split(r"[\\.-]", _v) if _v is not None else None
+
+    _version = _parse_version(_rocm_version)
+    for fname in [
+        "version",
+        "version-dev",
+        "version-hip-libraries",
+        "version-hiprt",
+        "version-hiprt-devel",
+        "version-hip-sdk",
+        "version-libs",
+        "version-utils",
+    ]:
+        if _version is not None and len(_version) > 0:
+            break
+        _fname = os.path.join(_rocm_path, ".info", fname)
+        if os.path.exists(_fname):
+            with open(_fname, "r") as f:
+                _version = _parse_version(f.readlines()[0].strip("\n"))
+
+    if _version is not None and len(_version) > 0:
+        _major = int(_version[0])
+        _minor = int(_version[1]) if len(_version) >= 2 else 0
+        _rocm_version = f"{_major}.{_minor}"
+        return "-ROCm-{}".format((10000 * _major) + (100 * _minor))
+    return None
+
+
+def get_os_info(os_distrib, os_version):
+
+    _os_info = {}
+    with open("/etc/os-release", "r") as f:
+        for line in [_v.strip() for _v in f.readlines()]:
+            _key, _data = line.split("=", 1)
+            _os_info[_key] = _data.strip('"')
+
+    if os_distrib is None or os_distrib == "auto":
+        if "debian" in _os_info["ID_LIKE"]:
+            os_distrib = "ubuntu"
+        elif "suse" in _os_info["ID_LIKE"]:
+            os_distrib = "opensuse"
+        else:
+            raise RuntimeError(
+                "Unknown ID_LIKE value in /etc/os-release: {}".format(_os_info["ID_LIKE"])
+            )
+
+    if os_version is None:
+
+        def _parse_version(_v):
+            _version = re.split(r"[\\.-]", _v)
+            return "{}.{}".format(_version[0], _version[1])
+
+        os_version = _parse_version(_os_info["VERSION_ID"])
+
+    return (os_distrib, os_version)
+
+
+def print_log(*args, **kwargs):
+
+    sys.stdout.flush()
+    sys.stderr.flush()
+    sys.stderr.write("### ")
+    sys.stderr.write(*args, **kwargs)
+    sys.stderr.write("\n")
+    sys.stderr.flush()
+
+
+def run(*args, **kwargs):
+
+    print_log("Executing: {}\n".format(" ".join(*args)))
+    sp.run(*args, **kwargs, check=True)
+    sys.stderr.write("\n")
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--version",
+        help="Print omnitrace version which will be installed",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-p", "--prefix", help="Installation prefix", type=str, default="/opt/omnitrace"
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        help="Prompt to accept the license and include/exclude subdirectory",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-D",
+        "--download-path",
+        help="Download directory (default: temporary directory)",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "-d",
+        "--os-distrib",
+        help="Target OS distribution",
+        type=str,
+        default=None,
+        choices=("auto", "ubuntu", "opensuse"),
+    )
+    parser.add_argument(
+        "-v", "--os-version", help="Target OS version", type=str, default=None
+    )
+    parser.add_argument(
+        "-k",
+        "--keep-download",
+        help="Do not delete downloaded file as installation",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--rocm",
+        help="Install omnitrace with ROCm support. Accepts either a ROCm version (e.g. '5.4') or the root path to the ROCm install containing .info/version* file(s) (e.g. /opt/rocm if /opt/rocm/.info/version exists). If no argument is provided, the ROCm version will attempted to be deduced from $ENV{ROCM_PATH}/.info/version",
+        nargs="?",
+        default=None,
+        const=True,
+        metavar="VERSION or ROCM_PATH with .info/version file(s)",
+    )
+    # right now, only valid set of extensions are: papi + ompt + python3
+    # in the future, this might change, e.g. MPI variants
+    parser.add_argument(
+        "-e",
+        "--extensions",
+        help="Omnitrace extensions, e.g. PAPI, OMPT, and Python3",
+        nargs="*",
+        default=("papi", "ompt", "python3"),
+        choices=("papi", "ompt", "python3"),
+    )
+
+    args = parser.parse_args()
+
+    if args.version:
+        print(f"omnitrace {omnitrace_version}")
+        sys.exit(0)
+
+    os_distrib, os_version = get_os_info(args.os_distrib, args.os_version)
+    rocm_version = get_rocm_version(args.rocm) if args.rocm is not None else ""
+    extensions = ""
+    if "papi" in args.extensions:
+        extensions += "-PAPI"
+    if "ompt" in args.extensions:
+        extensions += "-OMPT"
+    if "python3" in args.extensions:
+        extensions += "-Python3"
+
+    if rocm_version is None:
+        raise RuntimeError(
+            f"Error! ROCm version could not be determined from {_rocm_path}/.info/version*. Please provide a ROCm version or the root path to the ROCm install containing the .info directory, e.g. '--rocm 5.4' or '--rocm /path/to/rocm/install'"
+        )
+
+    script = f"omnitrace-{omnitrace_version}-{os_distrib}-{os_version}{rocm_version}{extensions}.sh"
+    url = f"https://github.com/AMDResearch/omnitrace/releases/download/v{omnitrace_version}/{script}"
+    download_dir = (
+        tempfile.mkdtemp(prefix="omnitrace-install-")
+        if args.download_path is None
+        else args.download_path
+    )
+    install_script = os.path.join(download_dir, script)
+
+    try:
+        if not os.path.exists(download_dir):
+            print_log(f"Creating download directory: {download_dir} ...")
+            os.makedirs(download_dir)
+
+        print_log(f"Downloading {url} ...")
+
+        try:
+            response = request.urlretrieve(url, install_script)
+        except HTTPError as e:
+            print_log(f"")
+            print_log(f"Error: {e}")
+            print_log(f"")
+            print_log(f"Error: Installer script download from {url} failed!")
+            if args.rocm is not None:
+                print_log(
+                    f"There may not be a pre-built installer for ROCm version {_rocm_version}"
+                )
+            sys.exit(-1)
+
+        if os.path.exists(install_script):
+            print_log(f"Download completed: {install_script}")
+        else:
+            raise RuntimeError(f"Download completed but {install_script} does not exist")
+
+        os.chmod(install_script, stat.S_IRWXU)
+
+        if not os.path.exists(args.prefix):
+            print_log(f"Creating directory: {args.prefix} ...")
+            os.makedirs(args.prefix)
+
+        install_args = (
+            ["--exclude-subdir", "--skip-license"] if not args.interactive else []
+        )
+
+        print_log(f"Installing omnitrace to {args.prefix} ...")
+
+        run([install_script, f"--prefix={args.prefix}"] + install_args)
+
+        print_log(
+            f"omnitrace v{omnitrace_version} installation to {args.prefix} succeeded!"
+        )
+
+    finally:
+        if not args.keep_download:
+            print_log(f"Removing install script {install_script} ...")
+            os.remove(install_script)
+            # remove the directory if it is a temporary directory
+            if args.download_path is None:
+                print_log(f"Removing temporary directory {download_dir} ...")
+                os.rmdir(download_dir)

--- a/scripts/write-omnitrace-install.cmake
+++ b/scripts/write-omnitrace-install.cmake
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.8)
+
+if(NOT DEFINED OMNITRACE_VERSION)
+    file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" FULL_VERSION_STRING LIMIT_COUNT 1)
+    string(REGEX REPLACE "(\n|\r)" "" FULL_VERSION_STRING "${FULL_VERSION_STRING}")
+    string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)(.*)" "\\1.\\2.\\3"
+                         OMNITRACE_VERSION "${FULL_VERSION_STRING}")
+endif()
+
+if(NOT DEFINED OUTPUT_DIR)
+    set(OUTPUT_DIR ${CMAKE_CURRENT_LIST_DIR})
+endif()
+
+message(
+    STATUS
+        "Writing ${OUTPUT_DIR}/omnitrace-install.py for omnitrace v${OMNITRACE_VERSION}")
+
+configure_file(${CMAKE_CURRENT_LIST_DIR}/../cmake/Templates/omnitrace-install.py.in
+               ${OUTPUT_DIR}/omnitrace-install.py @ONLY)


### PR DESCRIPTION
- omnitrace-install.py will be uploaded as a release asset
- script simplifies selecting the correct installer script

## Docker Example

```console
ARG OMNITRACE_VERSION=latest
ARG ROCM_VERSION=5.3

RUN wget https://github.com/AMDResearch/omnitrace/releases/download/${OMNITRACE_VERSION}/omnitrace-install.py && \
    python3 omnitrace-install.py --rocm ${ROCM_VERSION} && \
    rm omnitrace-install.py
```

## Options

```console
$ python3 omnitrace-install.py --help
usage: omnitrace-install.py [-h] [--version] [-p PREFIX] [-i]
                            [-D DOWNLOAD_PATH] [-d {auto,ubuntu,opensuse}]
                            [-v OS_VERSION] [-k]
                            [--rocm [VERSION or ROCM_PATH with .info/version files]]
                            [-e [{papi,ompt,python3} [{papi,ompt,python3} ...]]]

optional arguments:
  -h, --help            show this help message and exit
  --version             Print omnitrace version which will be installed
  -p PREFIX, --prefix PREFIX
                        Installation prefix
  -i, --interactive     Prompt to accept the license and include/exclude
                        subdirectory
  -D DOWNLOAD_PATH, --download-path DOWNLOAD_PATH
                        Download directory (default: temporary directory)
  -d {auto,ubuntu,opensuse}, --os-distrib {auto,ubuntu,opensuse}
                        Target OS distribution
  -v OS_VERSION, --os-version OS_VERSION
                        Target OS version
  -k, --keep-download   Do not delete downloaded file as installation
  --rocm [VERSION or ROCM_PATH with .info/version file(s)]
                        Install omnitrace with ROCm support. Accepts either a
                        ROCm version (e.g. '5.4') or the root path to the ROCm
                        install containing .info/version* file(s) (e.g.
                        /opt/rocm if /opt/rocm/.info/version exists). If no
                        argument is provided, the ROCm version will attempted
                        to be deduced from $ENV{ROCM_PATH}/.info/version
  -e [{papi,ompt,python3} [{papi,ompt,python3} ...]], --extensions [{papi,ompt,python3} [{papi,ompt,python3} ...]]
                        Omnitrace extensions, e.g. PAPI, OMPT, and Python3
```

## Usage Example

```console
$ python3 omnitrace-install.py -p /usr/local/omnitrace --rocm 5.2
### Downloading https://github.com/AMDResearch/omnitrace/releases/download/v1.7.3/omnitrace-1.7.3-ubuntu-18.04-ROCm-50200-PAPI-OMPT-Python3.sh ...
### Download completed: /tmp/omnitrace-install-tjibafo7/omnitrace-1.7.3-ubuntu-18.04-ROCm-50200-PAPI-OMPT-Python3.sh
### Creating directory: /usr/local/omnitrace ...
### Installing omnitrace to /usr/local/omnitrace ...
### Executing: /tmp/omnitrace-install-tjibafo7/omnitrace-1.7.3-ubuntu-18.04-ROCm-50200-PAPI-OMPT-Python3.sh --prefix=/usr/local/omnitrace --exclude-subdir --skip-license

omnitrace Installer Version: 1.7.3, Copyright (c) Advanced Micro Devices, Inc.
This is a self-extracting archive.
The archive will be extracted to: /usr/local/omnitrace

Using target directory: /usr/local/omnitrace
Extracting, please wait...

Unpacking finished successfully

### omnitrace v1.7.3 installation to /usr/local/omnitrace succeeded!
### Removing install script /tmp/omnitrace-install-tjibafo7/omnitrace-1.7.3-ubuntu-18.04-ROCm-50200-PAPI-OMPT-Python3.sh ...
### Removing temporary directory /tmp/omnitrace-install-tjibafo7 ...
```