### PR TITLE
HIP API and Activity Config Options + metadata JSON PID tagging

### DIFF
--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -24,7 +24,6 @@ ARG AMDGPU_RPM=latest/sle/15/amdgpu-install-21.50.50000-1.noarch.rpm
 
 RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         zypper --no-gpg-checks install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
-        zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/SLE_15/devel:languages:perl.repo && \
         zypper --non-interactive --gpg-auto-import-keys refresh && \
         amdgpu-install --usecase=rocm,hip,hiplibsdk --no-dkms -y && \
         zypper install -y rocm-hip-sdk rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel && \

--- a/source/lib/omnitrace/library.cpp
+++ b/source/lib/omnitrace/library.cpp
@@ -962,7 +962,7 @@ omnitrace_finalize_hidden(void)
         tim::timemory_finalize(_timemory_manager.get());
 
         auto _cfg       = settings::compose_filename_config{};
-        _cfg.use_suffix = true;
+        _cfg.use_suffix = config::get_use_pid();
         _timemory_manager->write_metadata(settings::get_global_output_prefix(),
                                           "omnitrace", _cfg);
     }

--- a/source/lib/omnitrace/library/components/roctracer.cpp
+++ b/source/lib/omnitrace/library/components/roctracer.cpp
@@ -155,15 +155,24 @@ roctracer::setup()
                              "invalid domain ID(4)  in: roctracer_enable_activity()" };
 #endif
 
-    OMNITRACE_ROCTRACER_CALL(roctracer_enable_domain_callback(ACTIVITY_DOMAIN_HIP_API,
-                                                              hip_api_callback, nullptr));
+    if(get_trace_hip_api())
+    {
+        OMNITRACE_ROCTRACER_CALL(roctracer_enable_domain_callback(
+            ACTIVITY_DOMAIN_HIP_API, hip_api_callback, nullptr));
+    }
+
     if(get_use_roctx())
     {
         OMNITRACE_ROCTRACER_CALL(roctracer_enable_domain_callback(
             ACTIVITY_DOMAIN_ROCTX, roctx_api_callback, nullptr));
     }
-    // Enable HIP activity tracing
-    OMNITRACE_ROCTRACER_CALL(roctracer_enable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS));
+
+    if(get_trace_hip_activity())
+    {
+        // Enable HIP activity tracing
+        OMNITRACE_ROCTRACER_CALL(
+            roctracer_enable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS));
+    }
 
     // callback for HSA
     for(auto& itr : roctracer_setup_routines())
@@ -212,14 +221,31 @@ roctracer::shutdown()
     };
 #endif
 
-    // OMNITRACE_ROCTRACER_CALL(roctracer_disable_domain_callback(ACTIVITY_DOMAIN_ROCTX));
-    OMNITRACE_VERBOSE_F(
-        2, "executing roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API)...\n");
-    OMNITRACE_ROCTRACER_CALL(roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API));
+    if(get_trace_hip_api())
+    {
+        OMNITRACE_VERBOSE_F(
+            2,
+            "executing roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API)...\n");
+        OMNITRACE_ROCTRACER_CALL(
+            roctracer_disable_domain_callback(ACTIVITY_DOMAIN_HIP_API));
+    }
 
-    OMNITRACE_VERBOSE_F(
-        2, "executing roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS)...\n");
-    OMNITRACE_ROCTRACER_CALL(roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS));
+    if(get_use_roctx())
+    {
+        OMNITRACE_VERBOSE_F(
+            2, "executing roctracer_disable_domain_activity(ACTIVITY_DOMAIN_ROCTX)...\n");
+        OMNITRACE_ROCTRACER_CALL(
+            roctracer_disable_domain_callback(ACTIVITY_DOMAIN_ROCTX));
+    }
+
+    if(get_trace_hip_activity())
+    {
+        OMNITRACE_VERBOSE_F(
+            2,
+            "executing roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS)...\n");
+        OMNITRACE_ROCTRACER_CALL(
+            roctracer_disable_domain_activity(ACTIVITY_DOMAIN_HIP_OPS));
+    }
 
     if(roctracer_activity_count() == 0)
     {

--- a/source/lib/omnitrace/library/config.cpp
+++ b/source/lib/omnitrace/library/config.cpp
@@ -561,6 +561,14 @@ configure_settings(bool _init)
             std::to_string(_sigrt_range),
         0, "sampling", "advanced");
 
+    OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_ROCTRACER_HIP_API",
+                             "Enable HIP API tracing support", true, "roctracer", "rocm",
+                             "advanced");
+
+    OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_ROCTRACER_HIP_ACTIVITY",
+                             "Enable HIP activity tracing support", true, "roctracer",
+                             "rocm", "advanced");
+
     OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_ROCTRACER_HSA_ACTIVITY",
                              "Enable HSA activity tracing support", false, "roctracer",
                              "rocm", "advanced");
@@ -1739,6 +1747,20 @@ get_sampling_rtoffset()
 {
     static auto _v = get_config()->find("OMNITRACE_SAMPLING_REALTIME_OFFSET");
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
+}
+
+bool
+get_trace_hip_api()
+{
+    static auto _v = get_config()->find("OMNITRACE_ROCTRACER_HIP_API");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+}
+
+bool
+get_trace_hip_activity()
+{
+    static auto _v = get_config()->find("OMNITRACE_ROCTRACER_HIP_ACTIVITY");
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool

--- a/source/lib/omnitrace/library/config.hpp
+++ b/source/lib/omnitrace/library/config.hpp
@@ -221,6 +221,12 @@ bool
 get_use_rcclp();
 
 bool
+get_trace_hip_api();
+
+bool
+get_trace_hip_activity();
+
+bool
 get_trace_hsa_api();
 
 bool


### PR DESCRIPTION
- new configuration options: `OMNITRACE_ROCTRACER_HIP_API` and `OMNITRACE_ROCTRACER_HIP_ACTIVITY`
  - formerly whenever `OMNITRACE_USE_ROCTRACER` was `ON`, there was no option to turn off tracing the HIP API will still tracing kernels (activity) or vice versa
  - `OMNITRACE_ROCTRACER_HIP_API`: enable/disable tracing HIP API function calls
  - `OMNITRACE_ROCTRACER_HIP_ACTIVITY`: enable/disable tracing HIP kernels
  - Named similarly to `OMNITRACE_ROCTRACER_HSA_API` and `OMNITRACE_ROCTRACER_HSA_ACTIVITY`
  - Similar to HSA options, the values of these settings are meaningless if `OMNITRACE_USE_ROCTRACER` is `OFF`
- In previous PR (~#190), omnitrace started always generating a `metadata.json` and `functions.json` as `metadata-<PID>.json` and `functions-<PID>.json` regardless of the setting of `OMNITRACE_USE_PID`
  - The idea was this might be helpful for multiple runs that overwrite the previous output, etc. (viewing command-line, env differences, etc.) but in reality it just leads to file clutter
  - This has been removed, now the metadata/function files use the same rules as every other output file
- Fixed docker issue for OpenSUSE + ROCm that was causing CPack to fail (removed adding perl zypper repo)