### PR TITLE
Causal profiling fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,10 +233,19 @@ endif()
 
 include(ProcessorCount)
 processorcount(OMNITRACE_PROCESSOR_COUNT)
-math(EXPR OMNITRACE_THREAD_COUNT "16 * ${OMNITRACE_PROCESSOR_COUNT}")
-if(OMNITRACE_THREAD_COUNT LESS 128)
+
+if(OMNITRACE_PROCESSOR_COUNT LESS 8)
     set(OMNITRACE_THREAD_COUNT 128)
+else()
+    math(EXPR OMNITRACE_THREAD_COUNT "16 * ${OMNITRACE_PROCESSOR_COUNT}")
+    compute_pow2_ceil(OMNITRACE_THREAD_COUNT "16 * ${OMNITRACE_PROCESSOR_COUNT}")
+
+    # set the default to 2048 if it could not be calculated
+    if(OMNITRACE_THREAD_COUNT LESS 2)
+        set(OMNITRACE_THREAD_COUNT 2048)
+    endif()
 endif()
+
 set(OMNITRACE_MAX_THREADS
     "${OMNITRACE_THREAD_COUNT}"
     CACHE
@@ -247,6 +256,21 @@ omnitrace_add_feature(
     OMNITRACE_MAX_THREADS
     "Maximum number of total threads supported in the host application (default: max of 128 or 16 * nproc)"
     )
+
+compute_pow2_ceil(_MAX_THREADS "${OMNITRACE_MAX_THREADS}")
+
+if(_MAX_THREADS GREATER 0 AND NOT OMNITRACE_MAX_THREADS EQUAL _MAX_THREADS)
+    omnitrace_message(
+        FATAL_ERROR
+        "Error! OMNITRACE_MAX_THREADS must be a power of 2. Recommendation: ${_MAX_THREADS}"
+        )
+elseif(NOT OMNITRACE_MAX_THREADS EQUAL _MAX_THREADS)
+    omnitrace_message(
+        AUTHOR_WARNING
+        "OMNITRACE_MAX_THREADS (=${OMNITRACE_MAX_THREADS}) must be a power of 2. We were unable to verify it so we are emitting this warning instead. Estimate resulted in: ${_MAX_THREADS}"
+        )
+endif()
+
 set(OMNITRACE_MAX_UNWIND_DEPTH
     "64"
     CACHE

--- a/cmake/MacroUtilities.cmake
+++ b/cmake/MacroUtilities.cmake
@@ -892,4 +892,34 @@ function(OMNITRACE_INSTALL_TPL _TPL_TARGET _NEW_NAME _BUILD_TREE_DIR _COMPONENT)
 
 endfunction()
 
+function(COMPUTE_POW2_CEIL _OUTPUT _VALUE)
+    find_package(Python3 COMPONENTS Interpreter)
+
+    if(Python3_FOUND)
+        execute_process(
+            COMMAND
+                ${Python3_EXECUTABLE} -c
+                "VALUE = ${_VALUE}; ispow2 = lambda x: x if (x and (not(x & (x - 1)))) else None; v = list(filter(ispow2, [x for x in range(VALUE, VALUE**2)])); print(v[0])"
+            RESULT_VARIABLE _POW2_RET
+            OUTPUT_VARIABLE _POW2_OUT
+            ERROR_VARIABLE _POW2_ERR
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        if(_POW2_RET EQUAL 0)
+            set(${_OUTPUT}
+                ${_POW2_OUT}
+                PARENT_SCOPE)
+        else()
+            set(${_OUTPUT}
+                "-1"
+                PARENT_SCOPE)
+        endif()
+    else()
+        set(${_OUTPUT}
+            "-1"
+            PARENT_SCOPE)
+    endif()
+
+endfunction()
+
 cmake_policy(POP)

--- a/source/bin/omnitrace-causal/impl.cpp
+++ b/source/bin/omnitrace-causal/impl.cpp
@@ -43,6 +43,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <gnu/lib-names.h>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -340,7 +341,9 @@ prepare_environment_for_run(std::vector<char*>& _env)
     if(launcher.empty())
     {
         update_env(_env, "LD_PRELOAD",
-                   get_realpath(get_internal_libpath("libomnitrace-dl.so")), true);
+                   join(":", LIBPTHREAD_SO,
+                        get_realpath(get_internal_libpath("libomnitrace-dl.so"))),
+                   true);
     }
 }
 

--- a/source/lib/omnitrace/library/causal/components/backtrace.hpp
+++ b/source/lib/omnitrace/library/causal/components/backtrace.hpp
@@ -45,6 +45,14 @@ namespace causal
 {
 namespace component
 {
+struct sample_rate
+: tim::component::empty_base
+, tim::concepts::component
+{
+    using value_type = void;
+    static void sample(int = -1);
+};
+
 struct backtrace
 : tim::component::empty_base
 , tim::concepts::component

--- a/source/lib/omnitrace/library/causal/data.cpp
+++ b/source/lib/omnitrace/library/causal/data.cpp
@@ -467,6 +467,9 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
         }
     }
 
+    // allow ~10 samples to be collected
+    std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+
     double _delay_sec =
         config::get_setting_value<double>("OMNITRACE_CAUSAL_DELAY").second;
     double _duration_sec =

--- a/source/lib/omnitrace/library/causal/delay.cpp
+++ b/source/lib/omnitrace/library/causal/delay.cpp
@@ -97,9 +97,6 @@ int64_t sleep_for_overhead = compute_sleep_for_overhead();
 void
 delay::process()
 {
-    if(!trait::runtime_enabled<delay>::get()) return;
-    if(get_state() >= ::omnitrace::State::Finalized) return;
-
     if(causal::experiment::is_active())
     {
         if(get_global() < get_local())
@@ -126,9 +123,6 @@ delay::process()
 void
 delay::credit()
 {
-    if(!trait::runtime_enabled<delay>::get()) return;
-    if(get_state() >= ::omnitrace::State::Finalized) return;
-
     auto _diff = get_global() - get_local();
     if(_diff > 0)
     {
@@ -139,9 +133,6 @@ delay::credit()
 void
 delay::preblock()
 {
-    if(!trait::runtime_enabled<delay>::get()) return;
-    if(get_state() >= ::omnitrace::State::Finalized) return;
-
     auto _diff = get_global() - get_local();
     if(_diff > 0)
     {
@@ -152,9 +143,6 @@ delay::preblock()
 void
 delay::postblock(int64_t _preblock_global_delay_value)
 {
-    if(!trait::runtime_enabled<delay>::get()) return;
-    if(get_state() >= ::omnitrace::State::Finalized) return;
-
     get_local() += (get_global() - _preblock_global_delay_value);
 }
 

--- a/source/lib/omnitrace/library/causal/sampling.cpp
+++ b/source/lib/omnitrace/library/causal/sampling.cpp
@@ -60,7 +60,8 @@ namespace sampling
 using ::tim::sampling::dynamic;
 using ::tim::sampling::timer;
 
-using causal_bundle_t  = tim::lightweight_tuple<causal::component::backtrace>;
+using causal_bundle_t =
+    tim::lightweight_tuple<causal::component::sample_rate, causal::component::backtrace>;
 using causal_sampler_t = tim::sampling::sampler<causal_bundle_t, dynamic>;
 }  // namespace sampling
 }  // namespace causal
@@ -305,6 +306,20 @@ unblock_samples()
 {
     trait::runtime_enabled<causal::component::backtrace>::set(true);
     trait::runtime_enabled<causal_sampler_t>::set(true);
+}
+
+void
+block_backtrace_samples()
+{
+    trait::runtime_enabled<causal::component::backtrace>::set(scope::thread_scope{},
+                                                              false);
+}
+
+void
+unblock_backtrace_samples()
+{
+    trait::runtime_enabled<causal::component::backtrace>::set(scope::thread_scope{},
+                                                              true);
 }
 
 void

--- a/source/lib/omnitrace/library/causal/sampling.hpp
+++ b/source/lib/omnitrace/library/causal/sampling.hpp
@@ -45,6 +45,12 @@ block_samples();
 void
 unblock_samples();
 
+void
+block_backtrace_samples();
+
+void
+unblock_backtrace_samples();
+
 void block_signals(std::set<int> = {});
 
 void unblock_signals(std::set<int> = {});


### PR DESCRIPTION
- corrections in the calculations for latency and throughput points in `validate-causal-json.py`
- `omnitrace-causal` LD_PRELOAD libpthread
  - ensures omnitrace is always wrapping libpthread.so pthread symbols
- minimal experiment delay
  - always sleep 10 milliseconds before starting experiments
  - ensures ~10 samples are taken to determine the sampling rate
- fixes issue with deadlocks on condition variables
- overhaul of `causal::component::blocking_gotcha` and `causal::component::unblocking_gotcha` components
  - these components enforce the processing/crediting of delays before/after a thread is suspended
  - these components wrap functions `pthread_cond_wait`, `pthread_cond_signal`, `pthread_mutex_lock`, etc.
- Fully implemented correct handling of processing/crediting delays based on return values and arguments
  - E.g. skip crediting delay if `pthread_mutex_trylock` fail acquiring lock
  - E.g. `kill`, `sigwait`, etc. check to make sure they are only applied if the PID matches its PID
 
## Condition Variable Deadlock Fix

In parallel applications using condition variables, it was found that the causal profiling was virtually guaranteed to deadlock. Although it was difficult to prove, evidence suggested that this was due to the work that was being done while taking a sample was causing notification to the condition variable to be lost. This was alleviated by the following updates:
 
- Separate out the part of `causal::backtrace::sample(int)` which calculates the sampling rate into small `sample_rate` component
  - This component is essentially "always on"  during sampling
  - Added bundle of components invoked by `causal_sampler_t` during sampling
- Added two function calls to support disabling and re-enabling calls to `causal::backtrace::sample(int)` on a per-thread basis 
  - `causal::sampling::block_backtrace_samples()`
  - `causal::sampling::unblock_backtrace_samples()`
  - These two function now surround the wrappee functions of `blocking_gotcha` and `unblocking_gotcha`

**This solution was experimentally validated with a Geant4 application which uses a tasking model which makes _numerous_ calls to wait on a condition variables** (it was this application which exposed the bug)