### PR TITLE
Causal profiling GUI: error bars

### DIFF
--- a/source/python/gui/source/gui.py
+++ b/source/python/gui/source/gui.py
@@ -147,6 +147,9 @@ def update_line_graph(sortFilter, func_list, exp_list, data, numPoints, samples)
                     go.Scatter(
                         x=sub_data_prog["Line Speedup"],
                         y=sub_data_prog["Program Speedup"],
+                        error_y=dict(
+                            type="percent", array=sub_data_prog["impact err"].tolist()
+                        ),
                         line_shape="spline",
                         name=prog,
                         mode="lines+markers",
@@ -161,6 +164,9 @@ def update_line_graph(sortFilter, func_list, exp_list, data, numPoints, samples)
                     go.Scatter(
                         x=sub_data_prog["Line Speedup"],
                         y=sub_data_prog["Program Speedup"],
+                        error_y=dict(
+                            type="percent", array=sub_data_prog["impact err"].tolist()
+                        ),
                         line_shape="spline",
                         name=prog,
                         mode="lines+markers",

--- a/source/python/gui/source/parser.py
+++ b/source/python/gui/source/parser.py
@@ -51,7 +51,7 @@ def stddev(_data):
         return 0.0
     _mean = mean(_data)
     _variance = sum([((x - _mean) ** 2) for x in _data]) / float(len(_data))
-    return _variance ** 0.5
+    return _variance**0.5
 
 
 class validation(object):

--- a/source/python/gui/source/parser.py
+++ b/source/python/gui/source/parser.py
@@ -51,7 +51,7 @@ def stddev(_data):
         return 0.0
     _mean = mean(_data)
     _variance = sum([((x - _mean) ** 2) for x in _data]) / float(len(_data))
-    return _variance**0.5
+    return _variance ** 0.5
 
 
 class validation(object):
@@ -422,7 +422,7 @@ def compute_speedups(_data, speedups=[], num_points=0, validate=[], CLI=False):
                                     "Program Speedup": [speedup],
                                     "impact sum": impact[0],
                                     "impact avg": impact[1],
-                                    "impact err": f"{impact[2]:6.2f}",
+                                    "impact err": float(impact[2]),
                                 }
                             ),
                         ],
@@ -819,10 +819,10 @@ def getSpeedupData(data):
                                 "point": [name],
                                 "speedup": [speedup],
                                 "progress_speedup": [100 * progress_speedup],
-                            },
+                            }
                         ),
                         speedup_df,
-                    ],
+                    ]
                 )
     speedup_df = speedup_df.sort_values(by=["speedup"])
     return speedup_df


### PR DESCRIPTION
I am going to merge this but it is using the wrong standard deviation data. The error bars should reflect the experiment progress point standard deviation at a specific virtual speedup, not the impact standard deviation. In other words, the error bar should show how much variance is in the virtual speedup prediction.