### PR TITLE
Update entrypoint-rhel.sh

### DIFF
--- a/docker/entrypoint-rhel.sh
+++ b/docker/entrypoint-rhel.sh
@@ -3,7 +3,7 @@
 if [ -f /etc/profile.d/modules.sh ]; then
     source /etc/profile.d/modules.sh
     module load mpi &> /dev/null
-endif
+fi
 
 if [ -z "${1}" ]; then
     : ${SHELL:=/bin/bash}


### PR DESCRIPTION
- fix endif instead of fi typo in bash script