### PR TITLE
libomnitrace-dl updates

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -21,7 +21,6 @@ parse:
     omnitrace_add_test:
       flags:
         - SKIP_BASELINE
-        - SKIP_PRELOAD
         - SKIP_REWRITE
         - SKIP_RUNTIME
         - SKIP_SAMPLING
@@ -33,15 +32,15 @@ parse:
         NUM_PROCS: '*'
         REWRITE_TIMEOUT: '*'
         RUNTIME_TIMEOUT: '*'
-        PRELOAD_TIMEOUT: '*'
+        SAMPLING_TIMEOUT: '*'
         REWRITE_ARGS: '*'
         RUNTIME_ARGS: '*'
         RUN_ARGS: '*'
         ENVIRONMENT: '*'
         LABELS: '*'
         PROPERTIES: '*'
-        PRELOAD_PASS_REGEX: '*'
-        PRELOAD_FAIL_REGEX: '*'
+        SAMPLING_PASS_REGEX: '*'
+        SAMPLING_FAIL_REGEX: '*'
         RUNTIME_PASS_REGEX: '*'
         RUNTIME_FAIL_REGEX: '*'
         REWRITE_PASS_REGEX: '*'

--- a/source/bin/omnitrace-avail/CMakeLists.txt
+++ b/source/bin/omnitrace-avail/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(omnitrace-avail PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_compile_definitions(omnitrace-avail PRIVATE OMNITRACE_EXTERN_COMPONENTS=0)
 target_link_libraries(
     omnitrace-avail
-    PRIVATE omnitrace::omnitrace-compile-definitions
+    PRIVATE omnitrace::omnitrace-compile-options omnitrace::omnitrace-compile-definitions
             omnitrace::omnitrace-interface-library omnitrace::libomnitrace-static)
 set_target_properties(
     omnitrace-avail PROPERTIES BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"

--- a/source/bin/omnitrace-causal/CMakeLists.txt
+++ b/source/bin/omnitrace-causal/CMakeLists.txt
@@ -13,8 +13,8 @@ target_compile_definitions(omnitrace-causal PRIVATE TIMEMORY_CMAKE=1)
 target_include_directories(omnitrace-causal PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(
     omnitrace-causal
-    PRIVATE omnitrace::omnitrace-compile-definitions omnitrace::omnitrace-headers
-            omnitrace::omnitrace-common-library)
+    PRIVATE omnitrace::omnitrace-compile-options omnitrace::omnitrace-compile-definitions
+            omnitrace::omnitrace-headers omnitrace::omnitrace-common-library)
 set_target_properties(
     omnitrace-causal PROPERTIES BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                                 INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")

--- a/source/bin/omnitrace-causal/impl.cpp
+++ b/source/bin/omnitrace-causal/impl.cpp
@@ -155,7 +155,7 @@ wait_pid(pid_t _pid, int _opts)
         if((_opts & WNOHANG) > 0)
             std::this_thread::sleep_for(std::chrono::milliseconds{ 100 });
         _pid_v = waitpid(_pid, &_status, _opts);
-    } while(_pid <= 0);
+    } while(_pid_v <= 0);
     return _status;
 }
 
@@ -840,7 +840,6 @@ parse_args(int argc, char** argv, std::vector<char*>& _env,
         throw std::runtime_error(_cerr.what());
 
     if(_niterations < 1) _niterations = 1;
-    auto _get_size = [](const auto& _v) { return std::max<size_t>(_v.size(), 1); };
 
     auto _causal_envs_tmp = std::vector<std::map<std::string_view, std::string>>{};
     auto _fill = [&_causal_envs_tmp](std::string_view _env_var, const auto& _data,

--- a/source/bin/omnitrace-critical-trace/CMakeLists.txt
+++ b/source/bin/omnitrace-critical-trace/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(omnitrace-critical-trace PRIVATE ${CMAKE_CURRENT_LIST
 target_compile_definitions(omnitrace-critical-trace PRIVATE OMNITRACE_EXTERN_COMPONENTS=0)
 target_link_libraries(
     omnitrace-critical-trace
-    PRIVATE omnitrace::omnitrace-compile-definitions
+    PRIVATE omnitrace::omnitrace-compile-options omnitrace::omnitrace-compile-definitions
             omnitrace::omnitrace-interface-library omnitrace::omnitrace-headers
             omnitrace::omnitrace-timemory omnitrace::libomnitrace-static)
 set_target_properties(

--- a/source/bin/omnitrace-run/CMakeLists.txt
+++ b/source/bin/omnitrace-run/CMakeLists.txt
@@ -13,9 +13,9 @@ target_compile_definitions(omnitrace-run PRIVATE TIMEMORY_CMAKE=1)
 target_include_directories(omnitrace-run PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(
     omnitrace-run
-    PRIVATE omnitrace::omnitrace-compile-definitions omnitrace::omnitrace-headers
-            omnitrace::omnitrace-common-library omnitrace::omnitrace-core
-            omnitrace::omnitrace-sanitizer)
+    PRIVATE omnitrace::omnitrace-compile-options omnitrace::omnitrace-compile-definitions
+            omnitrace::omnitrace-headers omnitrace::omnitrace-common-library
+            omnitrace::omnitrace-core omnitrace::omnitrace-sanitizer)
 set_target_properties(
     omnitrace-run PROPERTIES BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                              INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")

--- a/source/bin/omnitrace-run/impl.cpp
+++ b/source/bin/omnitrace-run/impl.cpp
@@ -274,12 +274,6 @@ parse_args(int argc, char** argv, parser_data_t& _parser_data)
     // no need for backtraces
     signals::disable_signal_detection(signals::signal_settings::get_enabled());
 
-    auto help_check = [](parser_t& p, int _argc, char** _argv) {
-        std::set<std::string> help_args = { "-h", "--help", "-?" };
-        return (p.exists("help") || _argc == 1 ||
-                (_argc > 1 && help_args.find(_argv[1]) != help_args.end()));
-    };
-
     const auto* _desc = R"desc(
     Command line interface to omnitrace configuration.
     )desc";
@@ -349,7 +343,6 @@ parse_command(int argc, char** argv, parser_data_t& _parser_data)
     signals::disable_signal_detection(signals::signal_settings::get_enabled());
 
     auto& _outv = _parser_data.command;
-    bool  _hash = false;
     for(int i = 1; i < argc; ++i)
     {
         _outv.emplace_back(strdup(argv[i]));

--- a/source/bin/omnitrace-sample/CMakeLists.txt
+++ b/source/bin/omnitrace-sample/CMakeLists.txt
@@ -11,8 +11,8 @@ target_compile_definitions(omnitrace-sample PRIVATE TIMEMORY_CMAKE=1)
 target_include_directories(omnitrace-sample PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(
     omnitrace-sample
-    PRIVATE omnitrace::omnitrace-compile-definitions omnitrace::omnitrace-headers
-            omnitrace::omnitrace-common-library)
+    PRIVATE omnitrace::omnitrace-compile-options omnitrace::omnitrace-compile-definitions
+            omnitrace::omnitrace-headers omnitrace::omnitrace-common-library)
 set_target_properties(
     omnitrace-sample PROPERTIES BUILD_RPATH "\$ORIGIN:\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
                                 INSTALL_RPATH "${OMNITRACE_EXE_INSTALL_RPATH}")

--- a/source/docs/development.md
+++ b/source/docs/development.md
@@ -24,7 +24,7 @@ General design:
 - Adds `libomnitrace-dl.so` to `LD_PRELOAD`
 - Application is launched via `execvpe` with `<command> <command-args>` and modified environment
 
-### omnitrace-casual: [source/bin/omnitrace-causal](https://github.com/AMDResearch/omnitrace/tree/main/source/bin/omnitrace-causal)
+### omnitrace-causal: [source/bin/omnitrace-causal](https://github.com/AMDResearch/omnitrace/tree/main/source/bin/omnitrace-causal)
 
 Nearly identical design to [omnitrace-sample](#omnitrace-sample-sourcebinomnitrace-sample) when
 there is exactly one causal profiling configuration variant (this enables debugging).

--- a/source/lib/common/environment.hpp
+++ b/source/lib/common/environment.hpp
@@ -168,6 +168,8 @@ struct OMNITRACE_INTERNAL_API env_config
     std::string env_value = {};
     int         override  = 0;
 
+    void sync() { env_value = get_env(env_name, env_value); }
+
     auto operator()(bool _verbose = false) const
     {
         if(env_name.empty()) return -1;

--- a/source/lib/core/categories.hpp
+++ b/source/lib/core/categories.hpp
@@ -34,6 +34,7 @@
 #include <timemory/api/macros.hpp>
 #include <timemory/mpl/macros.hpp>
 #include <timemory/mpl/types.hpp>
+#include <timemory/utility/types.hpp>
 
 #define OMNITRACE_DEFINE_NAME_TRAIT(NAME, DESC, ...)                                     \
     namespace tim                                                                        \
@@ -203,6 +204,8 @@ using name = perfetto_category<Tp...>;
 
 namespace omnitrace
 {
+namespace scope = ::tim::scope;
+
 inline namespace config
 {
 std::set<std::string>
@@ -219,6 +222,14 @@ enable_categories(const std::set<std::string>& = config::get_enabled_categories(
 
 void
 disable_categories(const std::set<std::string>& = config::get_disabled_categories());
+
+void
+enable_categories(scope::thread_scope,
+                  const std::set<std::string>& = config::get_enabled_categories());
+
+void
+disable_categories(scope::thread_scope,
+                   const std::set<std::string>& = config::get_disabled_categories());
 
 void
 setup();

--- a/source/lib/omnitrace/library.cpp
+++ b/source/lib/omnitrace/library.cpp
@@ -157,8 +157,8 @@ ensure_finalization(bool _static_init = false)
 
     if(_static_init)
     {
-        _timemory_manager->add_finalize_callback([](const tim::manager* const _manager) {
-            if(_manager->get_tid() != 0 && !_manager->get_is_main_thread())
+        _timemory_manager->add_finalize_callback([](const tim::manager* const) {
+            if(threading::get_id() > 0)
                 categories::disable_categories(scope::thread_scope{});
         });
     }

--- a/source/lib/omnitrace/library.cpp
+++ b/source/lib/omnitrace/library.cpp
@@ -152,8 +152,16 @@ ensure_finalization(bool _static_init = false)
 
     if(common::get_env("OMNITRACE_MONOCHROME", false)) tim::log::monochrome() = true;
 
-    (void) tim::manager::instance();
-    (void) tim::settings::shared_instance();
+    if(!_timemory_manager) _timemory_manager = tim::manager::instance();
+    if(!_timemory_settings) _timemory_settings = tim::settings::shared_instance();
+
+    if(_static_init)
+    {
+        _timemory_manager->add_finalize_callback([](const tim::manager* const _manager) {
+            if(_manager->get_tid() != 0 && !_manager->get_is_main_thread())
+                categories::disable_categories(scope::thread_scope{});
+        });
+    }
 
     if(!tim::get_shared_ptr_pair_callback())
     {

--- a/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
@@ -199,6 +199,7 @@ pthread_create_gotcha::wrapper::operator()() const
                 _thr_bundle->stop();
             if(_bundle) stop_bundle(*_bundle, _tid);
             pthread_create_gotcha::shutdown(_tid);
+            categories::disable_categories(scope::thread_scope{});
             OMNITRACE_BASIC_VERBOSE(
                 1, "[PID=%i][rank=%i] Thread %s (parent: %s) exited\n", process::get_id(),
                 dmp::rank(), _info->index_data->as_string().c_str(),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ omnitrace_add_test(
     ENVIRONMENT "${_base_environment};OMNITRACE_CRITICAL_TRACE=ON")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_RUNTIME
+    SKIP_BASELINE SKIP_RUNTIME
     NAME transpose-loops
     TARGET transpose
     LABELS "loops"
@@ -97,7 +97,7 @@ omnitrace_add_test(
     REWRITE_FAIL_REGEX "0 instrumented loops in procedure transpose")
 
 omnitrace_add_test(
-    SKIP_PRELOAD SKIP_RUNTIME SKIP_SAMPLING
+    SKIP_SAMPLING SKIP_RUNTIME
     NAME rewrite-caller
     TARGET rewrite-caller
     LABELS "caller-include"
@@ -123,7 +123,7 @@ set(OMNITRACE_ROCM_EVENTS_TEST
 
 if(OMNITRACE_USE_ROCPROFILER)
     omnitrace_add_test(
-        SKIP_BASELINE SKIP_SAMPLING SKIP_RUNTIME
+        SKIP_BASELINE SKIP_RUNTIME
         NAME transpose-rocprofiler
         TARGET transpose
         LABELS "rocprofiler"
@@ -138,7 +138,7 @@ if(OMNITRACE_USE_ROCPROFILER)
         )
 
     omnitrace_add_test(
-        SKIP_BASELINE SKIP_SAMPLING SKIP_RUNTIME
+        SKIP_BASELINE SKIP_RUNTIME
         NAME transpose-rocprofiler-no-roctracer
         TARGET transpose
         LABELS "rocprofiler"
@@ -186,7 +186,7 @@ omnitrace_add_test(
     )
 
 omnitrace_add_test(
-    SKIP_RUNTIME SKIP_SAMPLING
+    SKIP_RUNTIME
     NAME parallel-overhead-locks-timemory
     TARGET parallel-overhead-locks
     LABELS "locks"
@@ -200,7 +200,7 @@ omnitrace_add_test(
     )
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING
+    SKIP_BASELINE SKIP_RUNTIME
     NAME parallel-overhead-locks-perfetto
     TARGET parallel-overhead-locks
     LABELS "locks"
@@ -232,7 +232,7 @@ omnitrace_add_test(
     ENVIRONMENT "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF"
     REWRITE_RUN_PASS_REGEX "Pushing custom region :: run.10. x 1000"
     RUNTIME_PASS_REGEX "Pushing custom region :: run.10. x 1000"
-    PRELOAD_PASS_REGEX "Pushing custom region :: run.10. x 1000"
+    SAMPLING_PASS_REGEX "Pushing custom region :: run.10. x 1000"
     BASELINE_FAIL_REGEX "Pushing custom region"
     REWRITE_FAIL_REGEX "0 instrumented loops in procedure")
 
@@ -262,7 +262,7 @@ if(OMNITRACE_USE_MPI OR OMNITRACE_USE_MPI_HEADERS)
         )
 
     omnitrace_add_test(
-        SKIP_RUNTIME SKIP_SAMPLING
+        SKIP_RUNTIME
         NAME "mpi-flat-mpip"
         TARGET mpi-example
         MPI ON
@@ -285,7 +285,7 @@ if(OMNITRACE_USE_MPI OR OMNITRACE_USE_MPI_HEADERS)
         )
 
     omnitrace_add_test(
-        SKIP_RUNTIME SKIP_SAMPLING
+        SKIP_RUNTIME
         NAME "mpi-flat"
         TARGET mpi-example
         MPI ON
@@ -339,7 +339,7 @@ if(OMNITRACE_USE_MPI OR OMNITRACE_USE_MPI_HEADERS)
             set(_mpip_${_EXAMPLE}_environment "${_mpip_environment}")
         endif()
         omnitrace_add_test(
-            SKIP_RUNTIME SKIP_SAMPLING SKIP_PRELOAD
+            SKIP_RUNTIME SKIP_SAMPLING
             NAME "mpi-${_EXAMPLE}"
             TARGET mpi-${_EXAMPLE}
             MPI ON
@@ -428,7 +428,7 @@ omnitrace_add_test(
         "${_base_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=ON")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING
+    SKIP_BASELINE
     NAME lulesh-perfetto
     TARGET lulesh
     MPI ${LULESH_USE_MPI}
@@ -451,7 +451,6 @@ omnitrace_add_test(
         "${_perfetto_environment};OMNITRACE_CRITICAL_TRACE=OFF;OMNITRACE_USE_KOKKOSP=OFF")
 
 omnitrace_add_test(
-    SKIP_SAMPLING
     NAME lulesh-timemory
     TARGET lulesh
     MPI ${LULESH_USE_MPI}
@@ -482,7 +481,6 @@ else()
 endif()
 
 omnitrace_add_test(
-    SKIP_SAMPLING
     NAME openmp-cg
     TARGET openmp-cg
     LABELS "openmp"
@@ -509,7 +507,7 @@ omnitrace_add_test(
     REWRITE_RUN_PASS_REGEX "${_OMPT_PASS_REGEX}"
     REWRITE_FAIL_REGEX "0 instrumented loops in procedure")
 
-set(_ompt_preload_environ
+set(_ompt_sampling_environ
     "${_ompt_environment}"
     "OMNITRACE_VERBOSE=2"
     "OMNITRACE_USE_OMPT=OFF"
@@ -536,42 +534,42 @@ set(_ompt_sample_no_tmpfiles_environ
     "OMNITRACE_USE_TEMPORARY_FILES=OFF"
     "OMNITRACE_MONOCHROME=ON")
 
-set(_ompt_preload_samp_regex
+set(_ompt_sampling_samp_regex
     "Sampler for thread 0 will be triggered 1000.0x per second of CPU-time(.*)Sampler for thread 0 will be triggered 500.0x per second of wall-time(.*)Sampling will be disabled after 0.250000 seconds(.*)Sampling duration of 0.250000 seconds has elapsed. Shutting down sampling"
     )
-set(_ompt_preload_file_regex
-    "sampling-duration-preload/sampling_percent.(json|txt)(.*)sampling-duration-preload/sampling_cpu_clock.(json|txt)(.*)sampling-duration-preload/sampling_wall_clock.(json|txt)"
+set(_ompt_sampling_file_regex
+    "sampling-duration-sampling/sampling_percent.(json|txt)(.*)sampling-duration-sampling/sampling_cpu_clock.(json|txt)(.*)sampling-duration-sampling/sampling_wall_clock.(json|txt)"
     )
-set(_notmp_preload_file_regex
-    "sampling-no-tmp-files-preload/sampling_percent.(json|txt)(.*)sampling-no-tmp-files-preload/sampling_cpu_clock.(json|txt)(.*)sampling-no-tmp-files-preload/sampling_wall_clock.(json|txt)"
+set(_notmp_sampling_file_regex
+    "sampling-no-tmp-files-sampling/sampling_percent.(json|txt)(.*)sampling-no-tmp-files-sampling/sampling_cpu_clock.(json|txt)(.*)sampling-no-tmp-files-sampling/sampling_wall_clock.(json|txt)"
     )
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE SKIP_SAMPLING
+    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
     NAME openmp-cg-sampling-duration
     TARGET openmp-cg
     LABELS "openmp;sampling-duration"
-    ENVIRONMENT "${_ompt_preload_environ}"
-    PRELOAD_PASS_REGEX "${_ompt_preload_samp_regex}(.*)${_ompt_preload_file_regex}")
+    ENVIRONMENT "${_ompt_sampling_environ}"
+    SAMPLING_PASS_REGEX "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE SKIP_SAMPLING
+    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
     NAME openmp-lu-sampling-duration
     TARGET openmp-lu
     LABELS "openmp;sampling-duration"
-    ENVIRONMENT "${_ompt_preload_environ}"
-    PRELOAD_PASS_REGEX "${_ompt_preload_samp_regex}(.*)${_ompt_preload_file_regex}")
+    ENVIRONMENT "${_ompt_sampling_environ}"
+    SAMPLING_PASS_REGEX "${_ompt_sampling_samp_regex}(.*)${_ompt_sampling_file_regex}")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE SKIP_SAMPLING
+    SKIP_BASELINE SKIP_RUNTIME SKIP_REWRITE
     NAME openmp-cg-sampling-no-tmp-files
     TARGET openmp-cg
     LABELS "openmp;no-tmp-files"
     ENVIRONMENT "${_ompt_sample_no_tmpfiles_environ}"
-    PRELOAD_PASS_REGEX "${_notmp_preload_file_regex}")
+    SAMPLING_PASS_REGEX "${_notmp_sampling_file_regex}")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_PRELOAD
+    SKIP_BASELINE SKIP_SAMPLING
     NAME code-coverage
     TARGET code-coverage
     REWRITE_ARGS
@@ -610,7 +608,7 @@ omnitrace_add_test(
     REWRITE_RUN_PASS_REGEX "(\\\[[0-9]+\\\]) code coverage     ::  66.67%")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_PRELOAD
+    SKIP_BASELINE SKIP_SAMPLING
     NAME code-coverage-hybrid
     TARGET code-coverage
     REWRITE_ARGS -e -v 2 --min-instructions=4 -E ^std:: --coverage function
@@ -637,7 +635,7 @@ omnitrace_add_test(
     REWRITE_RUN_PASS_REGEX "(\\\[[0-9]+\\\]) code coverage     ::  66.67%")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_PRELOAD
+    SKIP_BASELINE SKIP_SAMPLING
     NAME code-coverage-basic-blocks
     TARGET code-coverage
     REWRITE_ARGS
@@ -676,7 +674,7 @@ omnitrace_add_test(
     REWRITE_RUN_PASS_REGEX "(\\\[[0-9]+\\\]) function coverage ::  66.67%")
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_PRELOAD
+    SKIP_BASELINE SKIP_SAMPLING
     NAME code-coverage-basic-blocks-hybrid
     TARGET code-coverage
     REWRITE_ARGS -e -v 2 --min-instructions=4 -E ^std:: --coverage basic_block
@@ -707,7 +705,7 @@ if(_OS_RELEASE STREQUAL "ubuntu-18.04")
 endif()
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_PRELOAD ${_TRACE_WINDOW_SKIP}
+    SKIP_BASELINE SKIP_SAMPLING ${_TRACE_WINDOW_SKIP}
     NAME trace-time-window
     TARGET trace-time-window
     REWRITE_ARGS -e -v 2 --caller-include inner -i 4096
@@ -766,7 +764,7 @@ omnitrace_add_validation_test(
          -p)
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_SAMPLING SKIP_PRELOAD ${_TRACE_WINDOW_SKIP}
+    SKIP_BASELINE SKIP_SAMPLING ${_TRACE_WINDOW_SKIP}
     NAME trace-time-window-delay
     TARGET trace-time-window
     REWRITE_ARGS -e -v 2 --caller-include inner -i 4096
@@ -818,10 +816,10 @@ omnitrace_add_test(
     RUNTIME_ARGS -e -v 1 --label file -i 16
     ENVIRONMENT
         "${_base_environment};OMNITRACE_CRITICAL_TRACE=ON;OMNITRACE_SAMPLING_FREQ=250;OMNITRACE_SAMPLING_REALTIME=ON"
-    PRELOAD_PASS_REGEX "fork.. called on PID"
+    SAMPLING_PASS_REGEX "fork.. called on PID"
     RUNTIME_PASS_REGEX "fork.. called on PID"
     REWRITE_RUN_PASS_REGEX "fork.. called on PID"
-    PRELOAD_FAIL_REGEX
+    SAMPLING_FAIL_REGEX
         "(terminate called after throwing an instance|calling abort.. in |Exit code: [1-9])"
     RUNTIME_FAIL_REGEX
         "(terminate called after throwing an instance|calling abort.. in |Exit code: [1-9])"
@@ -836,7 +834,7 @@ omnitrace_add_test(
 # -------------------------------------------------------------------------------------- #
 
 omnitrace_add_test(
-    SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING SKIP_PRELOAD
+    SKIP_BASELINE SKIP_RUNTIME SKIP_SAMPLING
     NAME parallel-overhead-critical-trace
     TARGET parallel-overhead
     LABELS "critical-trace"
@@ -938,7 +936,6 @@ foreach(_TARGET ${RCCL_TEST_TARGETS})
     string(REPLACE "rccl-tests::" "" _NAME "${_TARGET}")
     string(REPLACE "_" "-" _NAME "${_NAME}")
     omnitrace_add_test(
-        SKIP_SAMPLING
         NAME rccl-test-${_NAME}
         TARGET ${_TARGET}
         LABELS "rccl-tests;rcclp"


### PR DESCRIPTION
- all bin exes use omnitrace-compile-options
- Fix unused variables in `omnitrace-causal` and `omnitrace-run`
- docs updates: casual -> causal
- common library and libomnitrace-dl updates 
  - set `OMNITRACE_LIBRARY`, `OMNITRACE_DL_LIBRARY`, `OMNITRACE_USER_LIBRARY` in `common::get_environ`
  - restructure initialization of indirect in `dl.cpp` (reduce local statics)
  - restructure global and thread state variables in `dl.cpp` (cache locality)

