### PR TITLE
rocprofler_iterate_info workaround v2

### DIFF
--- a/source/lib/omnitrace/library/rocm/hsa_rsrc_factory.cpp
+++ b/source/lib/omnitrace/library/rocm/hsa_rsrc_factory.cpp
@@ -467,12 +467,17 @@ HsaRsrcFactory::AddAgentInfo(const hsa_agent_t agent)
         agent_info->vgpr_block_size = 4;
 
         // Set GPU index
-        uint32_t driver_node_id;
+        /*uint32_t driver_node_id;
         status = hsa_api_.hsa_agent_get_info(
             agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID),
             &driver_node_id);
         CHECK_STATUS("hsa_agent_get_info(gpu hsa_driver_node_id)", status);
-        agent_info->dev_index = driver_node_id;
+        agent_info->dev_index = driver_node_id;*/
+        // disable this change above (found in the rocprofiler library)
+        // because it breaks the lookup for rocprofiler_pool_fetch
+        // lookup in rocprofiler.cpp. On my system (one AMD GPU and one NVIDIA GPU),
+        // it has a value of 1, not 0 and the pool size is 1
+        agent_info->dev_index = gpu_list_.size();
         gpu_list_.push_back(agent_info);
         gpu_agents_.push_back(agent);
     }


### PR DESCRIPTION
- Revert `agent_info->dev_index` to use old method in `hsa_rsrc_factory.cpp`
  - disable using the driver_node_id and, instead, start at zero because it breaks the lookup for `rocprofiler_pool_fetch` lookup in `rocprofiler.cpp`. On my system (one AMD GPU and one NVIDIA GPU), it has a value of 1, not 0 and the pool size is 1 leading to a segfault
- Fixes #268