### PR TITLE
Causal GUI: Linting, synced y-range, remove unused imports/variables, and bug fixes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,45 @@
+name: Python
+run-name: Python
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'source/python/gui/*.py'
+      - 'source/python/gui/**/*.py'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'source/python/gui/*.py'
+      - 'source/python/gui/**/*.py'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      working-directory: ${{ github.workspace }}/source/python/gui
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      working-directory: ${{ github.workspace }}/source/python/gui
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # flake8 options are defined in setup.cfg
+        flake8 . --count --statistics

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/source/python/gui/setup.cfg
+++ b/source/python/gui/setup.cfg
@@ -25,3 +25,9 @@ classifiers =
 packages = omnitrace_causal_viewer
 zip_safe = true
 include_package_data = true
+
+[flake8]
+ignore =
+    E501,
+    W503,
+max-line-length = 90

--- a/source/python/gui/setup.py
+++ b/source/python/gui/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import glob
-import shutil
 
 from setuptools import setup
 

--- a/source/python/gui/source/__main__.py
+++ b/source/python/gui/source/__main__.py
@@ -29,22 +29,16 @@ __license__ = "MIT"
 __maintainer__ = "AMD Research"
 __status__ = "Development"
 
-import sys
 import argparse
 import os.path
 import dash
 import dash_bootstrap_components as dbc
-import copy
 import json
-import glob
-import pandas as pd
 
 from pathlib import Path
-from yaml import parse
-from collections import OrderedDict
 
 from . import gui
-from .parser import parse_files, find_causal_files
+from .parser import parse_files, find_causal_files, set_num_stddev
 from . import __version__
 
 
@@ -59,7 +53,7 @@ def causal(args):
     # unique
     input_files = list(set(input_files))
 
-    num_stddev = args.stddev
+    set_num_stddev(args.stddev)
     num_speedups = len(args.speedups)
 
     if num_speedups > 0 and args.min_points > num_speedups:
@@ -142,7 +136,7 @@ def main():
     default_settings["min_points"] = 5
     default_settings["recursive"] = False
     default_settings["verbose"] = 0
-    default_settings["stddev"] = 1
+    default_settings["stddev"] = 1.0
 
     for key, value in default_settings.items():
         if key not in settings:
@@ -278,7 +272,7 @@ def main():
     my_parser.add_argument(
         "-d",
         "--stddev",
-        type=int,
+        type=float,
         help="Number of standard deviations to report",
         default=settings["stddev"],
     )

--- a/source/python/gui/source/gui.py
+++ b/source/python/gui/source/gui.py
@@ -31,24 +31,15 @@ __status__ = "Development"
 
 import glob
 import re
-import sys
-import copy
 import base64
 import os
 import pandas as pd
 import dash_bootstrap_components as dbc
 import plotly.express as px
 
-from re import L
-from selectors import EpollSelector
-from matplotlib.axis import XAxis
-from numpy import append
-from dash.dash_table import FormatTemplate
-from dash.dash_table.Format import Format, Scheme, Symbol
-from dash import html, dash_table
+from dash import html
 from dash.dependencies import Input, Output, State
 from dash import dcc, ctx
-from os.path import exists
 
 from .header import get_header
 from .parser import parse_files
@@ -63,6 +54,7 @@ global_samples = pd.DataFrame()
 global_input_filters = None
 workload_path = ""
 verbose = 0
+text_color = "white"
 
 pd.set_option(
     "mode.chained_assignment", None
@@ -89,13 +81,13 @@ def build_line_graph():
     layout1 = html.Div(
         id="graph_all",
         className="graph",
-        children=[html.H4("All Causal Profiles", style={"color": "white"})],
+        children=[html.H4("All Causal Profiles", style={"color": text_color})],
     )
 
     layout2 = html.Div(
         id="graph_select",
         className="graph",
-        children=[html.H4("Call Stack Sample Histogram", style={"color": "white"})],
+        children=[html.H4("Call Stack Sample Histogram", style={"color": text_color})],
     )
 
     return layout1, layout2
@@ -131,7 +123,27 @@ def update_line_graph(
             [colors_df, pd.DataFrame({"progress points": [prog], "color": [color * 100]})]
         )
 
-    causalLayout = [html.H4("Selected Causal Profiles", style={"color": "white"})]
+    causalLayout = [html.H4("Selected Causal Profiles", style={"color": text_color})]
+
+    # all the workload should start off with the same Y range so make comparisons easier
+    y_ranges = [0, 0]
+    for speedup, speedup_err in zip(mask["program speedup"], mask["speedup err"]):
+        y_ranges = [
+            min([y_ranges[0], speedup - speedup_err]),
+            max([y_ranges[1], speedup + speedup_err]),
+        ]
+    # add some extra room
+    y_ranges = [
+        (round((y_ranges[0] - 5) / 10) * 10) - 1,
+        (round((y_ranges[1] + 5) / 10) * 10) + 1,
+    ]
+    # enforce an absolute lower bound and an abosulte upper bound
+    # bottom of y_range will not be greater than -1 and not less than -125
+    # top of y_range will not be less than 1 and not greater than 125
+    y_ranges = [
+        max([min([-1, y_ranges[0]]), -125]),
+        min([max([1, y_ranges[1]]), 125]),
+    ]
 
     for point in list(mask.point.unique()):
         subplots = go.Figure()
@@ -148,20 +160,29 @@ def update_line_graph(
                     x=sub_data_prog["line speedup"],
                     y=sub_data_prog["program speedup"],
                     error_y=dict(
-                        type="percent", array=sub_data_prog["impact err"].tolist()
+                        type="data", array=sub_data_prog["speedup err"].tolist()
                     ),
                     line_shape="spline",
                     name=prog,
                     mode="lines+markers",
-                )
-            ).update_layout(xaxis={"title": x_label}, yaxis={"title": "Program Speedup"})
-        causalLayout.append(html.H4(point, style={"color": "white"}))
+                ),
+            ).update_xaxes(dtick=5).update_yaxes(range=y_ranges, dtick=10).update_layout(
+                xaxis={"title": x_label},
+                yaxis={"title": "Program Speedup"},
+                height=600,
+            )
+        causalLayout.append(html.H4(point, style={"color": text_color}))
         causalLayout.append(dcc.Graph(figure=subplots))
+
+    # compute the location with the most samples
+    _max_sample = samples.groupby(["location"]).sum()["count"].max()
+    # don't display samples < 1% of the peak
+    samples = samples[samples["count"] >= 0.01 * _max_sample]
 
     fig3 = px.bar(samples, x="location", y="count", height=1200)
 
     samplesLayout = [
-        html.H4("Call Stack Sample Histogram", style={"color": "white"}),
+        html.H4("Call Stack Sample Histogram", style={"color": text_color}),
         dcc.Graph(figure=fig3),
     ]
 
@@ -202,22 +223,22 @@ def build_causal_layout(
     global verbose
     global global_data
     global global_samples
-    global_data = data
-    global_samples = samples
     global global_input_filters
-    global_input_filters = input_filters
     global workload_path
-    workload_path = path_to_dir
+    global text_color
 
+    global_input_filters = input_filters
+    global_data = data
+    text_color = "black" if light_mode else "white"
+    workload_path = path_to_dir
     verbose = verbosity
+    global_samples = samples
 
     dropDownMenuItems = [
         dbc.DropdownMenuItem("Overview", header=True),
         dbc.DropdownMenuItem("All Causal Profiles"),
         dbc.DropdownMenuItem("Selected Causal Profiles"),
     ]
-
-    inital_min_points = 3
 
     app.layout = html.Div(
         style={"backgroundColor": "rgb(255, 255, 255)"}
@@ -247,8 +268,8 @@ def build_causal_layout(
         [Input("refresh", "n_clicks")],
         [Input("Sort by-filt", "value")],
         [Input("Select Workload-filt", "value")],
-        [Input("function_regex", "value")],
-        [Input("exp_regex", "value")],
+        [Input("experiment_regex", "value")],
+        [Input("progpt_regex", "value")],
         [Input("points-filt", "value")],
         [Input("file-path", "value")],
         [Input("upload-drag", "contents")],
@@ -260,8 +281,8 @@ def build_causal_layout(
         refresh,
         sort_filter,
         workload_filter,
-        func_regex,
-        exp_regex,
+        experiment_regex,
+        progpt_regex,
         num_points,
         _workload_path,
         contentsList,
@@ -276,8 +297,8 @@ def build_causal_layout(
         # change to if debug
         if verbose >= 3:
             print("Sort by is ", sort_filter)
-            print("funcRegex is ", func_regex)
-            print("expRegex is ", exp_regex)
+            print("experiment_regex is ", experiment_regex)
+            print("progress_point_regex is ", progpt_regex)
             print("points is: ", num_points)
             print("workload_path is: ", workload_path)
             print("selected workloads are:", workload_filter)
@@ -301,7 +322,7 @@ def build_causal_layout(
                 _files = glob.glob(os.path.join(_workload_path, "*.json"))
                 # subfiles = glob.glob(os.path.join(workload_path, "*/*.coz")) +
                 subfiles = glob.glob(os.path.join(_workload_path, "*/*.json"))
-                metadata = glob.glob(os.path.join(_workload_path, "*/metadata*.json"))
+                # metadata = glob.glob(os.path.join(_workload_path, "*/metadata*.json"))
                 files = _files + subfiles
                 workload_path = files
             global_data, global_samples, global_filenames = parse_files(
@@ -359,16 +380,16 @@ def build_causal_layout(
                 header = get_header(dropDownMenuItems, global_input_filters)
 
         # runs when function or experiment regex is changed, takes numPoints into account as well
-        elif func_regex is not None or exp_regex is not None:
-            if global_data.empty == False:
-                if func_regex is not None:
-                    p = re.compile(func_regex, flags=0)
+        elif experiment_regex is not None or progpt_regex is not None:
+            if not global_data.empty:
+                if experiment_regex is not None:
+                    p = re.compile(experiment_regex, flags=0)
 
                     func_list = [
                         s for s in list(global_data["point"].unique()) if p.match(s)
                     ]
-                if exp_regex is not None:
-                    p = re.compile(exp_regex, flags=0)
+                if progpt_regex is not None:
+                    p = re.compile(progpt_regex, flags=0)
 
                     exp_list = [
                         s
@@ -398,7 +419,7 @@ def build_causal_layout(
                 files=files, verbose=verbose
             )
 
-            if global_data.empty == False:
+            if not global_data.empty:
                 max_points = global_data.point.value_counts().max().max()
 
                 # reset input_filters
@@ -424,7 +445,7 @@ def build_causal_layout(
         else:
             func_list = []
             exp_list = []
-            if global_data.empty == False:
+            if not global_data.empty:
                 if verbose == 3:
                     print(global_data)
                 func_list = sorted(list(global_data.point.unique()))
@@ -438,7 +459,7 @@ def build_causal_layout(
                     global_samples,
                     workload_filter,
                 )
-        if screen_data.empty == False:
+        if not screen_data.empty:
             if verbose == 2:
                 print_speedup_info(screen_data)
             elif verbose >= 3:

--- a/source/python/gui/source/gui.py
+++ b/source/python/gui/source/gui.py
@@ -94,7 +94,7 @@ def build_line_graph():
 
 
 def update_line_graph(
-    sort_filter, func_list, exp_list, data, num_points, samples, workloads
+    sort_filter, experiment_list, progpt_list, data, num_points, samples, workloads
 ):
     if "Alphabetical" in sort_filter:
         data = data.sort_values(by=["point", "idx"])
@@ -111,8 +111,8 @@ def update_line_graph(
     if num_points > 0:
         data = data[data["point count"] > num_points]
 
-    mask = data[data.point.isin(func_list)]
-    mask = mask[mask["progress points"].isin(exp_list)]
+    mask = data[data.point.isin(experiment_list)]
+    mask = mask[mask["progress points"].isin(progpt_list)]
     mask = mask[mask["workload"].isin(workloads)]
 
     progress_points = list(mask["progress points"].unique())
@@ -308,8 +308,8 @@ def build_causal_layout(
         fig1 = None
         fig2 = None
         global new_data
-        global func_list
-        global exp_list
+        global experiment_list
+        global progpt_list
         global global_samples
         screen_data = pd.DataFrame()
 
@@ -328,8 +328,8 @@ def build_causal_layout(
             global_data, global_samples, global_filenames = parse_files(
                 workload_path, verbose=verbose
             )
-            func_list = sorted(list(global_data.point.unique()))
-            exp_list = sorted(list(global_data["progress points"].unique()))
+            experiment_list = sorted(list(global_data.point.unique()))
+            progpt_list = sorted(list(global_data["progress points"].unique()))
 
             max_points = global_data.point.value_counts().max().max()
 
@@ -339,8 +339,8 @@ def build_causal_layout(
 
             screen_data, fig1, fig2 = update_line_graph(
                 sort_filter,
-                func_list,
-                exp_list,
+                experiment_list,
+                progpt_list,
                 global_data,
                 num_points,
                 global_samples,
@@ -360,8 +360,8 @@ def build_causal_layout(
 
                 max_points = new_data.point.value_counts().max().max()
 
-                func_list = sorted(list(global_data.point.unique()))
-                exp_list = sorted(list(global_data["progress points"].unique()))
+                experiment_list = sorted(list(global_data.point.unique()))
+                progpt_list = sorted(list(global_data["progress points"].unique()))
 
                 # reset input_filters
                 global_input_filters = reset_input_filters(
@@ -370,8 +370,8 @@ def build_causal_layout(
 
                 screen_data, fig1, fig2 = update_line_graph(
                     sort_filter,
-                    func_list,
-                    exp_list,
+                    experiment_list,
+                    progpt_list,
                     new_data,
                     num_points,
                     global_samples,
@@ -385,13 +385,13 @@ def build_causal_layout(
                 if experiment_regex is not None:
                     p = re.compile(experiment_regex, flags=0)
 
-                    func_list = [
+                    experiment_list = [
                         s for s in list(global_data["point"].unique()) if p.match(s)
                     ]
                 if progpt_regex is not None:
                     p = re.compile(progpt_regex, flags=0)
 
-                    exp_list = [
+                    progpt_list = [
                         s
                         for s in list(global_data["progress points"].unique())
                         if p.match(s)
@@ -399,8 +399,8 @@ def build_causal_layout(
 
                 screen_data, fig1, fig2 = update_line_graph(
                     sort_filter,
-                    func_list,
-                    exp_list,
+                    experiment_list,
+                    progpt_list,
                     global_data,
                     num_points,
                     global_samples,
@@ -430,30 +430,30 @@ def build_causal_layout(
                 if verbose >= 3:
                     print(global_data.keys())
 
-                func_list = sorted(list(global_data.point.unique()))
-                exp_list = sorted(list(global_data["progress points"].unique()))
+                experiment_list = sorted(list(global_data.point.unique()))
+                progpt_list = sorted(list(global_data["progress points"].unique()))
 
                 screen_data, fig1, fig2 = update_line_graph(
                     sort_filter,
-                    func_list,
-                    exp_list,
+                    experiment_list,
+                    progpt_list,
                     global_data,
                     num_points,
                     global_samples,
                     global_filenames,
                 )
         else:
-            func_list = []
-            exp_list = []
+            experiment_list = []
+            progpt_list = []
             if not global_data.empty:
                 if verbose == 3:
                     print(global_data)
-                func_list = sorted(list(global_data.point.unique()))
-                exp_list = sorted(list(global_data["progress points"].unique()))
+                experiment_list = sorted(list(global_data.point.unique()))
+                progpt_list = sorted(list(global_data["progress points"].unique()))
                 screen_data, fig1, fig2 = update_line_graph(
                     sort_filter,
-                    func_list,
-                    exp_list,
+                    experiment_list,
+                    progpt_list,
                     global_data,
                     num_points,
                     global_samples,

--- a/source/python/gui/source/header.py
+++ b/source/python/gui/source/header.py
@@ -21,14 +21,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import sys
+import os
+
 import dash_daq as daq
 import dash_bootstrap_components as dbc
 
-from dash import html, dash_table, dcc
-from matplotlib.style import available
-
-import os
+from dash import html, dcc
 
 
 def file_path():
@@ -180,8 +178,8 @@ def get_header(dropDownMenuItems, input_filters):
             # sys.exit(1)
 
     header_nav = children_[0].children[0].children
-    filter_children.append(function_filter("function_regex", "Funtion/line regex"))
-    filter_children.append(function_filter("exp_regex", "Experiment regex"))
+    filter_children.append(function_filter("experiment_regex", "Experiment regex"))
+    filter_children.append(function_filter("progpt_regex", "Progress Point regex"))
     filter_children.append(file_path())
     filter_children.append(upload_file())
     # filter_children.append(refresh())
@@ -195,8 +193,8 @@ def get_header(dropDownMenuItems, input_filters):
         # html.Li(
         #     className="regex",
         #     children=[
-        #         function_filter("function_regex", "Funtion/line regex"),
-        #         function_filter("exp_regex", "Experiment regex"),
+        #         function_filter("experiment_regex", "Funtion/line regex"),
+        #         function_filter("progpt_regex", "Experiment regex"),
         #         file_path(),
         #         upload_file(),
         #     ],


### PR DESCRIPTION
## Bug Fixes

- Error bars for causal data
  - the +/- values were treated as percents of original value when in reality they were values
- Mislabeled `function_regex` and `exp_regex`
  - in the code, progress points were misinterpreted as "experiments" when, in fact, the function/line stuff was the experiments
- Unused dataframe creation in `add_latency`
- Latency points not showing up in plots from JSON data
  - looking for "arrivals" key instead of "arrival"
  - `latency_point` class had duplicate `__init__` functions
- `--stddev` argument unused
  - not effectively assigned to `num_stddev` in `parser.py`
 
## Miscellaneous

- Workflow which runs flake8 on `source/python/gui` files
- Removed numerous unused by assigned variables (flake8 linting error)
- Removed numerous unused imports (flake8 linting error)
- Replaced `if X == False` with `if not X` (flake8 linting error)
- The y-range of all plots is identical for all plots now
  - this vastly improves initial comparison of impact between plots