### PR TITLE
Remove docker hiplibsdk from amdgpu-install

### DIFF
--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -59,8 +59,8 @@ jobs:
         if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi && \
         dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir
         yum install -y https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/rhel/${{ matrix.os-release }}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
-        amdgpu-install --usecase=rocm,hip,hiplibsdk --no-dkms --skip-broken -y
-        yum install -y rocm-hip-sdk rocm-smi-lib roctracer-dev rocprofiler-dev
+        amdgpu-install --usecase=rocm,hip --no-dkms --skip-broken -y
+        yum install -y rocm-smi-lib roctracer-dev rocprofiler-dev
 
     - name: Configure, Build, and Test
       timeout-minutes: 115

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -101,7 +101,7 @@ jobs:
           wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
           echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{ matrix.rocm-version }}/ jammy main" | tee /etc/apt/sources.list.d/rocm.list
           apt-get update
-          apt-get install -y {rocm-hip-sdk,roctracer-dev,rocprofiler-dev,rocm-smi-lib,rocminfo}${{ matrix.rocm-version }}.0
+          apt-get install -y {roctracer-dev,rocprofiler-dev,rocm-smi-lib,rocminfo}${{ matrix.rocm-version }}.0
           echo "/opt/rocm/bin" >> $GITHUB_PATH
           echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -26,8 +26,8 @@ RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         zypper addrepo https://mirrorcache-us.opensuse.org/repositories/devel:/languages:/perl/${PERL_REPO}/devel:languages:perl.repo && \
         zypper --no-gpg-checks install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
         zypper --non-interactive --gpg-auto-import-keys refresh && \
-        amdgpu-install --usecase=rocm,hip,hiplibsdk --no-dkms -y && \
-        zypper install -y rocm-hip-sdk rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel && \
+        amdgpu-install --usecase=rocm,hip --no-dkms -y && \
+        zypper install -y rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel && \
         zypper clean --all; \
     fi
 

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -26,8 +26,8 @@ RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi && \
         dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir && \
         yum install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
-        amdgpu-install --usecase=rocm,hip,hiplibsdk --no-dkms --skip-broken -y && \
-        yum install -y rocm-hip-sdk rocm-smi-lib roctracer-dev rocprofiler-dev && \
+        amdgpu-install --usecase=rocm,hip --no-dkms --skip-broken -y && \
+        yum install -y rocm-smi-lib roctracer-dev rocprofiler-dev && \
         yum clean all; \
     fi
 

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -260,7 +260,7 @@ do
                 ;;
             esac
             PERL_REPO="SLE_${VERSION_MAJOR}_SP${VERSION_MINOR}"
-            verbose-build docker build . ${PULL} -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO_IMAGE} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PERL_REPO=${PERL_REPO} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
+            verbose-build docker build . ${PULL} --progress plain -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO_IMAGE} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PERL_REPO=${PERL_REPO} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
         fi
         if [ "${PUSH}" -ne 0 ]; then
             docker push ${CONTAINER}


### PR DESCRIPTION
- amdgpu-install use case hiplibsdk is not necessary and bloats the install
- same as above for package rocm-hip-sdk