### PR TITLE
GitHub Actions workflow and docker updates

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/containers.yml'
+      - 'docker/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -120,13 +121,25 @@ jobs:
           - os-distro: "ubuntu"
             os-version: "20.04"
             rocm-version: "5.3"
-          # ubuntu 20.04
+          - os-distro: "ubuntu"
+            os-version: "20.04"
+            rocm-version: "5.4"
+          - os-distro: "ubuntu"
+            os-version: "20.04"
+            rocm-version: "5.5"
+          # ubuntu 22.04
           - os-distro: "ubuntu"
             os-version: "22.04"
             rocm-version: "0.0"
           - os-distro: "ubuntu"
             os-version: "22.04"
             rocm-version: "5.3"
+          - os-distro: "ubuntu"
+            os-version: "22.04"
+            rocm-version: "5.4"
+          - os-distro: "ubuntu"
+            os-version: "22.04"
+            rocm-version: "5.5"
           # opensuse 15.3
           - os-distro: "opensuse"
             os-version: "15.3"
@@ -146,6 +159,12 @@ jobs:
           - os-distro: "opensuse"
             os-version: "15.3"
             rocm-version: "5.3"
+          - os-distro: "opensuse"
+            os-version: "15.3"
+            rocm-version: "5.4"
+          - os-distro: "opensuse"
+            os-version: "15.3"
+            rocm-version: "5.5"
           # opensuse 15.4
           - os-distro: "opensuse"
             os-version: "15.4"
@@ -162,6 +181,43 @@ jobs:
           - os-distro: "opensuse"
             os-version: "15.4"
             rocm-version: "5.3"
+          - os-distro: "opensuse"
+            os-version: "15.4"
+            rocm-version: "5.4"
+          - os-distro: "opensuse"
+            os-version: "15.4"
+            rocm-version: "5.5"
+          # RHEL 8.7
+          - os-distro: "rhel"
+            os-version: "8.7"
+            rocm-version: "0.0"
+          - os-distro: "rhel"
+            os-version: "8.7"
+            rocm-version: "5.3"
+          - os-distro: "rhel"
+            os-version: "8.7"
+            rocm-version: "5.4"
+          # RHEL 9.0
+          - os-distro: "rhel"
+            os-version: "9.0"
+            rocm-version: "0.0"
+          - os-distro: "rhel"
+            os-version: "9.0"
+            rocm-version: "5.3"
+          - os-distro: "rhel"
+            os-version: "9.0"
+            rocm-version: "5.4"
+          # RHEL 9.1
+          - os-distro: "rhel"
+            os-version: "9.1"
+            rocm-version: "0.0"
+          - os-distro: "rhel"
+            os-version: "9.1"
+            rocm-version: "5.3"
+          - os-distro: "rhel"
+            os-version: "9.1"
+            rocm-version: "5.4"
+
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cpack.yml
+++ b/.github/workflows/cpack.yml
@@ -10,6 +10,11 @@ on:
     paths-ignore:
       - '*.md'
       - 'source/docs/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/cpack.yml'
+      - 'docker/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,15 +53,6 @@ jobs:
             rocm-version: "0.0"
           - os-distro: "ubuntu"
             os-version: "20.04"
-            rocm-version: "4.5"
-          - os-distro: "ubuntu"
-            os-version: "20.04"
-            rocm-version: "5.0"
-          - os-distro: "ubuntu"
-            os-version: "20.04"
-            rocm-version: "5.1"
-          - os-distro: "ubuntu"
-            os-version: "20.04"
             rocm-version: "5.2"
           - os-distro: "ubuntu"
             os-version: "20.04"
@@ -64,6 +60,9 @@ jobs:
           - os-distro: "ubuntu"
             os-version: "20.04"
             rocm-version: "5.4"
+          - os-distro: "ubuntu"
+            os-version: "20.04"
+            rocm-version: "5.5"
           # ubuntu 22.04
           - os-distro: "ubuntu"
             os-version: "22.04"
@@ -74,21 +73,15 @@ jobs:
           - os-distro: "ubuntu"
             os-version: "22.04"
             rocm-version: "5.4"
+          - os-distro: "ubuntu"
+            os-version: "22.04"
+            rocm-version: "5.5"
           # opensuse 15.3
           - os-distro: "opensuse"
             os-version: "15.3"
             rocm-version: "0.0"
           - os-distro: "opensuse"
             os-version: "15.3"
-            rocm-version: "4.5"
-          - os-distro: "opensuse"
-            os-version: "15.3"
-            rocm-version: "5.0"
-          - os-distro: "opensuse"
-            os-version: "15.3"
-            rocm-version: "5.1"
-          - os-distro: "opensuse"
-            os-version: "15.3"
             rocm-version: "5.2"
           - os-distro: "opensuse"
             os-version: "15.3"
@@ -96,18 +89,15 @@ jobs:
           - os-distro: "opensuse"
             os-version: "15.3"
             rocm-version: "5.4"
+          - os-distro: "opensuse"
+            os-version: "15.3"
+            rocm-version: "5.5"
           # opensuse 15.4
           - os-distro: "opensuse"
             os-version: "15.4"
             rocm-version: "0.0"
           - os-distro: "opensuse"
             os-version: "15.4"
-            rocm-version: "5.0"
-          - os-distro: "opensuse"
-            os-version: "15.4"
-            rocm-version: "5.1"
-          - os-distro: "opensuse"
-            os-version: "15.4"
             rocm-version: "5.2"
           - os-distro: "opensuse"
             os-version: "15.4"
@@ -115,6 +105,9 @@ jobs:
           - os-distro: "opensuse"
             os-version: "15.4"
             rocm-version: "5.4"
+          - os-distro: "opensuse"
+            os-version: "15.4"
+            rocm-version: "5.5"
           # RHEL 8.7
           - os-distro: "rhel"
             os-version: "8.7"
@@ -125,6 +118,9 @@ jobs:
           - os-distro: "rhel"
             os-version: "8.7"
             rocm-version: "5.4"
+          - os-distro: "rhel"
+            os-version: "8.7"
+            rocm-version: "5.5"
           # RHEL 9.0
           - os-distro: "rhel"
             os-version: "9.0"
@@ -135,6 +131,9 @@ jobs:
           - os-distro: "rhel"
             os-version: "9.0"
             rocm-version: "5.4"
+          - os-distro: "rhel"
+            os-version: "9.0"
+            rocm-version: "5.5"
           # RHEL 9.1
           - os-distro: "rhel"
             os-version: "9.1"
@@ -145,6 +144,9 @@ jobs:
           - os-distro: "rhel"
             os-version: "9.1"
             rocm-version: "5.4"
+          - os-distro: "rhel"
+            os-version: "9.1"
+            rocm-version: "5.5"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -77,7 +77,7 @@ jobs:
           -DOMNITRACE_USE_PYTHON=ON
           -DOMNITRACE_USE_MPI_HEADERS=ON
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
-          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DOMNITRACE_CI_MPI_RUN_AS_ROOT=ON
           -DOMNITRACE_MAX_THREADS=64
           -DOMNITRACE_DISABLE_EXAMPLES="transpose;rccl"
@@ -117,18 +117,20 @@ jobs:
         ./scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           build/omnitrace-tests-config/*.cfg
           build/omnitrace-tests-output/**/*.txt

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -1,4 +1,5 @@
 name: RedHat Linux (GCC, Python, ROCm)
+run-name: redhat
 
 on:
   push:
@@ -89,7 +90,7 @@ jobs:
           -DOMNITRACE_CI_MPI_RUN_AS_ROOT=ON
           -DOMNITRACE_MAX_THREADS=64
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
-          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DOMNITRACE_DISABLE_EXAMPLES="transpose;rccl"
           -DOMNITRACE_BUILD_NUMBER=${{ github.run_attempt }}
           --
@@ -115,18 +116,20 @@ jobs:
         ./scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           build/omnitrace-tests-config/*.cfg
           build/omnitrace-tests-output/**/*.txt

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -60,8 +60,7 @@ jobs:
         if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi && \
         dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir
         yum install -y https://repo.radeon.com/amdgpu-install/${{ matrix.rocm-version }}/rhel/${{ matrix.os-release }}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
-        amdgpu-install --usecase=rocm,hip --no-dkms --skip-broken -y
-        yum install -y rocm-smi-lib roctracer-dev rocprofiler-dev
+        yum install -y rocm-dev rocm-smi-lib roctracer-dev rocprofiler-dev
 
     - name: Configure, Build, and Test
       timeout-minutes: 115

--- a/.github/workflows/ubuntu-bionic.yml
+++ b/.github/workflows/ubuntu-bionic.yml
@@ -109,7 +109,7 @@ jobs:
           -DOMNITRACE_USE_HIP=OFF
           -DOMNITRACE_USE_PYTHON=ON
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
-          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DLULESH_BUILD_KOKKOS=OFF
           -DOMNITRACE_MAX_THREADS=64
           -DOMNITRACE_DISABLE_EXAMPLES="transpose;rccl"
@@ -148,18 +148,20 @@ jobs:
         ./scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           build/omnitrace-tests-config/*.cfg
           build/omnitrace-tests-output/**/*.txt

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -136,7 +136,7 @@ jobs:
           -DOMNITRACE_BUILD_STATIC_LIBGCC=${{ matrix.static-libgcc }}
           -DOMNITRACE_BUILD_STATIC_LIBSTDCXX=${{ matrix.static-libstdcxx }}
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
-          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DOMNITRACE_MAX_THREADS=64
           -DOMNITRACE_DISABLE_EXAMPLES="transpose;rccl"
           -DOMNITRACE_BUILD_NUMBER=${{ github.run_attempt }}
@@ -191,18 +191,20 @@ jobs:
         ./scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           build/omnitrace-tests-config/*.cfg
           build/omnitrace-tests-output/**/*.txt
@@ -224,17 +226,17 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['g++']
-        rocm-version: ['4.5', '5.0', '5.1', '5.2', '5.3']
+        rocm-version: ['5.2', '5.3', '5.4', '5.5']
         mpi-headers: ['OFF']
         build-jobs: ['3']
         ctest-exclude: ['-LE "mpi-example|transpose"']
         perfetto-tools: ['OFF']
         include:
           - compiler: 'g++'
-            rocm-version: '4.3'
-            mpi-headers: 'ON'
+            rocm-version: '4.5'
+            mpi-headers: 'OFF'
             build-jobs: '2'
-            ctest-exclude: '-LE transpose'
+            ctest-exclude: '-LE "mpi-example|transpose"'
             perfetto-tools: 'ON'
           - compiler: 'g++'
             rocm-version: 'debian'
@@ -264,16 +266,10 @@ jobs:
           wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - &&
           echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{ matrix.rocm-version }}/ ubuntu main" | tee /etc/apt/sources.list.d/rocm.list &&
           apt-get update &&
-          apt-get install -y build-essential m4 autoconf libtool python3-pip clang libomp-dev ${{ matrix.compiler }} libudev1 libnuma1 rocm-dev rocm-utils rocm-smi-lib roctracer-dev rocprofiler-dev hip-base hsa-amd-aqlprofile hsa-rocr-dev hsakmt-roct-dev libpapi-dev curl libopenmpi-dev openmpi-bin libfabric-dev &&
+          apt-get install -y build-essential m4 autoconf libtool python3-pip clang libomp-dev ${{ matrix.compiler }} libudev1 libnuma1 rocm-dev rocm-utils rocm-smi-lib roctracer-dev rocprofiler-dev rccl-dev hip-base hsa-amd-aqlprofile hsa-rocr-dev hsakmt-roct-dev libpapi-dev curl libopenmpi-dev openmpi-bin libfabric-dev &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install 'cmake==3.21.4' &&
           for i in 6 7 8 9 10; do /opt/conda/envs/py3.${i}/bin/python -m pip install numpy perfetto dataclasses; done
-
-    - name: Install RCCL
-      if: ${{ matrix.rocm-version != '4.3' }}
-      timeout-minutes: 10
-      run:
-        apt-get install -y rccl-dev
 
     - name: Configure Env
       run: |
@@ -331,7 +327,7 @@ jobs:
           -DOMNITRACE_USE_SANITIZER=OFF
           -DOMNITRACE_INSTALL_PERFETTO_TOOLS=${{ matrix.perfetto-tools }}
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
-          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_PYTHON_ENVS="py3.6;py3.7;py3.8;py3.9;py3.10;py3.11"
           -DOMNITRACE_CI_MPI_RUN_AS_ROOT=${{ matrix.mpi-headers }}
           -DOMNITRACE_CI_GPU=OFF
           -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=OFF
@@ -357,18 +353,20 @@ jobs:
         ./scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           omnitrace-tests-output/**/*.txt
           build/omnitrace-tests-config/*.cfg
@@ -524,18 +522,20 @@ jobs:
         ${{ github.workspace }}/scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           ${{ github.workspace }}/build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           ${{ github.workspace }}/build/omnitrace-tests-config/*.cfg
           ${{ github.workspace }}/build/omnitrace-tests-output/**/*.txt

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -116,7 +116,8 @@ jobs:
           wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
           echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{ matrix.rocm-version }}/ jammy main" | tee /etc/apt/sources.list.d/rocm.list
           apt-get update
-          apt-get install -y {rocm-dev,hip-dev,roctracer-dev,rocprofiler-dev,rocm-smi-lib,rocminfo}
+          ROCM_VERSION=$(apt-cache search rocm-dev[0-9] | awk '{print $1}' | sed 's/rocm-dev//g')
+          apt-get install -y {rocm-dev,hip-dev,roctracer-dev,rocprofiler-dev,rocm-smi-lib,rocminfo}${ROCM_VERSION}
           echo "/opt/rocm/bin" >> $GITHUB_PATH
           echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -62,6 +62,21 @@ jobs:
             static-libstdcxx: 'OFF'
             build-dyninst: 'OFF'
             rocm-version: '5.3'
+          - compiler: 'g++'
+            hip: 'ON'
+            mpi: 'OFF'
+            ompt: 'OFF'
+            papi: 'OFF'
+            python: 'ON'
+            lto: 'OFF'
+            strip: 'OFF'
+            hidden: 'ON'
+            build-type: 'Release'
+            mpi-headers: 'OFF'
+            static-libgcc: 'OFF'
+            static-libstdcxx: 'OFF'
+            build-dyninst: 'OFF'
+            rocm-version: 'latest'
 
     env:
       OMPI_ALLOW_RUN_AS_ROOT: 1
@@ -101,7 +116,7 @@ jobs:
           wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add -
           echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${{ matrix.rocm-version }}/ jammy main" | tee /etc/apt/sources.list.d/rocm.list
           apt-get update
-          apt-get install -y {rocm-dev,hip-dev,roctracer-dev,rocprofiler-dev,rocm-smi-lib,rocminfo}${{ matrix.rocm-version }}.0
+          apt-get install -y {rocm-dev,hip-dev,roctracer-dev,rocprofiler-dev,rocm-smi-lib,rocminfo}
           echo "/opt/rocm/bin" >> $GITHUB_PATH
           echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
@@ -162,7 +177,7 @@ jobs:
           -DOMNITRACE_BUILD_STATIC_LIBGCC=${{ matrix.static-libgcc }}
           -DOMNITRACE_BUILD_STATIC_LIBSTDCXX=${{ matrix.static-libstdcxx }}
           -DOMNITRACE_PYTHON_PREFIX=/opt/conda/envs
-          -DOMNITRACE_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10"
+          -DOMNITRACE_PYTHON_ENVS="py3.7;py3.8;py3.9;py3.10;py3.11"
           -DOMNITRACE_STRIP_LIBRARIES=${{ matrix.strip }}
           -DOMNITRACE_MAX_THREADS=64
           -DOMNITRACE_DISABLE_EXAMPLES="transpose;rccl"
@@ -199,18 +214,20 @@ jobs:
         ./scripts/test-find-package.sh --install-dir /opt/omnitrace
 
     - name: CTest Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: ctest-${{ github.job }}-log
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
         path: |
           build/*.log
 
     - name: Data Artifacts
-      if: success() || failure()
+      if: failure()
+      continue-on-error: True
       uses: actions/upload-artifact@v3
       with:
-        name: data-${{ github.job }}-files
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
         path: |
           build/omnitrace-tests-config/*.cfg
           build/omnitrace-tests-output/**/*.txt

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -11,6 +11,7 @@ WORKDIR /tmp
 SHELL [ "/bin/bash", "-c" ]
 
 ENV PATH /usr/local/bin:${PATH}
+ENV LIBRARY_PATH ${LIBRARY_PATH}:/opt/amdgpu/lib64
 
 RUN zypper update -y && \
     zypper dist-upgrade -y && \
@@ -27,7 +28,7 @@ RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         zypper --no-gpg-checks install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
         zypper --non-interactive --gpg-auto-import-keys refresh && \
         amdgpu-install --usecase=rocm,hip --no-dkms -y && \
-        zypper install -y rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel && \
+        zypper install -y rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel libpciaccess0 && \
         zypper clean --all; \
     fi
 

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -27,8 +27,7 @@ RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         zypper addrepo https://mirrorcache-us.opensuse.org/repositories/devel:/languages:/perl/${PERL_REPO}/devel:languages:perl.repo && \
         zypper --no-gpg-checks install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
         zypper --non-interactive --gpg-auto-import-keys refresh && \
-        amdgpu-install --usecase=rocm,hip --no-dkms -y && \
-        zypper install -y rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel libpciaccess0 && \
+        zypper install -y rocm-dev rocm-smi-lib roctracer-dev rocprofiler-dev rccl-devel libpciaccess0 && \
         zypper clean --all; \
     fi
 

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -11,6 +11,7 @@ WORKDIR /tmp
 SHELL [ "/bin/bash", "-c" ]
 
 ENV PATH /usr/local/bin:${PATH}
+ENV LIBRARY_PATH ${LIBRARY_PATH}:/opt/amdgpu/lib64
 
 RUN yum groupinstall -y "Development Tools" && \
     yum install -y epel-release && \

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -27,7 +27,7 @@ RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi && \
         dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir && \
         yum install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
-        yum install -y rocm-dev rocm-smi-lib roctracer-dev rocprofiler-dev && \
+        yum install -y rocm-dev rocm-smi-lib roctracer-dev rocprofiler-dev libpciaccess && \
         yum clean all; \
     fi
 

--- a/docker/Dockerfile.rhel
+++ b/docker/Dockerfile.rhel
@@ -26,8 +26,7 @@ RUN if [ "${ROCM_VERSION}" != "0.0" ]; then \
         if [ "${OS_VERSION_MAJOR}" -eq 8 ]; then PERL_REPO=powertools; else PERL_REPO=crb; fi && \
         dnf -y --enablerepo=${PERL_REPO} install perl-File-BaseDir && \
         yum install -y https://repo.radeon.com/amdgpu-install/${AMDGPU_RPM} && \
-        amdgpu-install --usecase=rocm,hip --no-dkms --skip-broken -y && \
-        yum install -y rocm-smi-lib roctracer-dev rocprofiler-dev && \
+        yum install -y rocm-dev rocm-smi-lib roctracer-dev rocprofiler-dev && \
         yum clean all; \
     fi
 

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -191,7 +191,7 @@ do
                 *)
                     ;;
             esac
-            verbose-build docker build . ${PULL} -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg ROCM_REPO_VERSION=${ROCM_REPO_VERSION} --build-arg ROCM_REPO_DIST=${ROCM_REPO_DIST} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
+            verbose-build docker build . ${PULL} --progress plain -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg ROCM_REPO_VERSION=${ROCM_REPO_VERSION} --build-arg ROCM_REPO_DIST=${ROCM_REPO_DIST} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
         elif [ "${DISTRO}" = "rhel" ]; then
             if [ -z "${VERSION_MINOR}" ]; then
                 send-error "Please provide a major and minor version of the OS. Supported: >= 8.7, <= 9.1"
@@ -220,7 +220,7 @@ do
             # use Rocky Linux as a base image for RHEL builds
             DISTRO_BASE_IMAGE=rockylinux
 
-            verbose-build docker build . ${PULL} -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO_BASE_IMAGE} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
+            verbose-build docker build . ${PULL} --progress plain -f ${DOCKER_FILE} --tag ${CONTAINER} --build-arg DISTRO=${DISTRO_BASE_IMAGE} --build-arg VERSION=${VERSION} --build-arg ROCM_VERSION=${ROCM_VERSION} --build-arg AMDGPU_RPM=${ROCM_RPM} --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\"
         elif [ "${DISTRO}" = "opensuse" ]; then
             case "${VERSION}" in
                 15.*)

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -173,7 +173,7 @@ do
                 4.1* | 4.0*)
                     ROCM_REPO_DIST="xenial"
                     ;;
-                5.3* | 5.4*)
+                5.3* | 5.4* | 5.5*)
                     case "${VERSION}" in
                         22.04)
                             ROCM_REPO_DIST="jammy"
@@ -204,14 +204,11 @@ do
 
             # set the sub-URL in https://repo.radeon.com/amdgpu-install/<sub-URL>
             case "${ROCM_VERSION}" in
-                5.4 | 5.4.*)
-                    ROCM_RPM=${ROCM_VERSION}/rhel/${RPM_PATH}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
-                    ;;
-                5.3 | 5.3.*)
+                5.3 | 5.3.* | 5.4 | 5.4.* | 5.5 | 5.5.*)
                     ROCM_RPM=${ROCM_VERSION}/rhel/${RPM_PATH}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1${RPM_TAG}.noarch.rpm
                     ;;
                 5.2 | 5.2.* | 5.1 | 5.1.* | 5.0 | 5.0.* | 4.*)
-                    send-error "Invalid ROCm version ${ROCM_VERSION}. Supported: >= 5.3.0, <= 5.4.x"
+                    send-error "Invalid ROCm version ${ROCM_VERSION}. Supported: >= 5.3.0, <= 5.5.x"
                     ;;
                 0.0)
                     ;;
@@ -235,10 +232,7 @@ do
                     ;;
             esac
             case "${ROCM_VERSION}" in
-                5.4 | 5.4.*)
-                    ROCM_RPM=${ROCM_VERSION}/sle/${VERSION}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.noarch.rpm
-                    ;;
-                5.3 | 5.3.*)
+                5.3 | 5.3.* | 5.4 | 5.4.* | 5.5 | 5.5.*)
                     ROCM_RPM=${ROCM_VERSION}/sle/${VERSION}/amdgpu-install-${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1.noarch.rpm
                     ;;
                 5.2 | 5.2.*)


### PR DESCRIPTION
- Support ROCm 5.5 in docker builds
- Update containers workflow
  - add Ubuntu and OpenSUSE container builds for ROCm 5.4 and 5.5
  - add RHEL builds
- Update CPack workflow
  - build on PR against main when cpack.yml or docker files updated
  - removed packaging for ROCm < 5.2 for many OSes
  - added packaging for ROCm 5.5
- Update OpenSUSE workflow
  - add python 3.11 to `OMNITRACE_PYTHON_ENVS` (creates additional tests)
  - upload-artifacts name includes strategy.job-index (prevent overwrite)
  - only upload artifacts on failure
  - continue on error if upload artifacts fails
- Update RedHat workflow
  - provide run-name
  - add python 3.11 to `OMNITRACE_PYTHON_ENVS` (creates additional tests)
  - upload-artifacts name includes strategy.job-index (prevent overwrite)
  - only upload artifacts on failure
  - continue on error if upload artifacts fails
- Update Ubuntu (bionic) workflow
  - add python 3.11 to `OMNITRACE_PYTHON_ENVS` (creates additional tests)
  - upload-artifacts name includes strategy.job-index (prevent overwrite)
  - only upload artifacts on failure
  - continue on error if upload artifacts fails
- Update Ubuntu (focal) workflow
  - add python 3.11 to `OMNITRACE_PYTHON_ENVS` (creates additional tests)
  - upload-artifacts name includes strategy.job-index (prevent overwrite)
  - only upload artifacts on failure
  - continue on error if upload artifacts fails
  - remove testing of ROCm 4.3, 5.0, 5.1
  - add testing of ROCm 5.5
- Update Ubuntu (jammy) workflow
  - add python 3.11 to `OMNITRACE_PYTHON_ENVS` (creates additional tests)
  - upload-artifacts name includes strategy.job-index (prevent overwrite)
  - only upload artifacts on failure
  - continue on error if upload artifacts fails
  - add testing of ROCm latest

