### PR TITLE
PyTorch Python fork fix

### DIFF
--- a/source/python/omnitrace/__main__.py
+++ b/source/python/omnitrace/__main__.py
@@ -401,8 +401,6 @@ if __name__ == "__main__":
         args = [args[0]] + ["--", _OMNITRACE_PYTHON_SCRIPT_FILE] + args[1:]
         os.environ["OMNITRACE_USE_PID"] = "ON"
 
-    print("argv: {} ({})".format(" ".join(args), " ".join(sys.argv)))
-
     main(args)
     from .libpyomnitrace import finalize
 

--- a/source/python/omnitrace/__main__.py
+++ b/source/python/omnitrace/__main__.py
@@ -40,7 +40,7 @@ import argparse
 import traceback
 
 PY3 = sys.version_info[0] == 3
-
+_OMNITRACE_PYTHON_SCRIPT_FILE = None
 
 # Python 3.x compatibility utils: execfile
 try:
@@ -270,27 +270,27 @@ def run(prof, cmd):
     prof.runctx(code, globs, None)
 
 
-def main():
+def main(main_args=sys.argv):
     """Main function"""
 
     opts = None
     argv = None
-    if "--" in sys.argv:
-        _idx = sys.argv.index("--")
-        _argv = sys.argv[(_idx + 1) :]
-        opts = parse_args(sys.argv[1:_idx])
+    if "--" in main_args:
+        _idx = main_args.index("--")
+        _argv = main_args[(_idx + 1) :]
+        opts = parse_args(main_args[1:_idx])
         argv = _argv
     else:
-        if "-h" in sys.argv or "--help" in sys.argv:
+        if "-h" in main_args or "--help" in main_args:
             opts = parse_args()
         else:
-            argv = sys.argv[1:]
+            argv = main_args[1:]
             opts = parse_args([])
             if len(argv) == 0 or not os.path.isfile(argv[0]):
                 raise RuntimeError(
-                    "Could not determine input script. Use '--' before "
+                    "Could not determine input script in '{}'. Use '--' before "
                     "the script and its arguments to ensure correct parsing. \nE.g. "
-                    "python -m omnitrace -- ./script.py"
+                    "python -m omnitrace -- ./script.py".format(" ".join(argv))
                 )
 
     if len(argv) > 1:
@@ -337,7 +337,7 @@ def main():
 
     print("[omnitrace]> profiling: {}".format(argv))
 
-    sys.argv[:] = argv
+    main_args[:] = argv
     if opts.setup is not None:
         # Run some setup code outside of the profiler. This is good for large
         # imports.
@@ -351,11 +351,13 @@ def main():
 
     from . import Profiler, FakeProfiler
 
-    script_file = find_script(sys.argv[0])
+    script_file = find_script(main_args[0])
     __file__ = script_file
     __name__ = "__main__"
     # Make sure the script's directory is on sys.path
     sys.path.insert(0, os.path.dirname(script_file))
+
+    _OMNITRACE_PYTHON_SCRIPT_FILE = script_file
 
     prof = Profiler()
     fake = FakeProfiler()
@@ -394,7 +396,14 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    args = sys.argv
+    if "--" not in args and _OMNITRACE_PYTHON_SCRIPT_FILE is not None:
+        args = [args[0]] + ["--", _OMNITRACE_PYTHON_SCRIPT_FILE] + args[1:]
+        os.environ["OMNITRACE_USE_PID"] = "ON"
+
+    print("argv: {} ({})".format(" ".join(args), " ".join(sys.argv)))
+
+    main(args)
     from .libpyomnitrace import finalize
 
     finalize()


### PR DESCRIPTION
- fixes issue where forking process in PyTorch causes `omnitrace/__main__.py` to fail due to missing script argument
- closes #284

## Test Cases

Follow basic setup steps in #284. 

> Note: on system used for testing (Lockhart) `LD_PRELOAD=/usr/lib64/libstdc++.so.6` was required due to `libstdc++.so.6` from conda env being too old for the ROCm libraries linked by omnitrace (omnitrace was built with `-static-libstdcxx`)

1. Configure stemdlConfig.yaml with 2 GPUs and execute `srun -G 2 python -m omnitrace -- ./stemdl_classification.py --config ./stemdlConfig.yaml`
2. Configure stemdlConfig.yaml with 4 GPUs and execute `srun -G 4 python -m omnitrace -- ./stemdl_classification.py --config ./stemdlConfig.yaml`
3. Wrote `run.sh` and execute `srun -G 2 ./run.sh`

### `run.sh` Contents

```shell
#!/bin/bash

set +e
pkill traced
pkill perfetto

set -e
traced --background
perfetto --out stemdl.proto --txt -c ./omni-perfetto.cfg --background

export OMNITRACE_PERFETTO_BACKEND=system
python -m omnitrace -- ./stemdl_classification.py --config ./stemdlConfig.yaml
```

### `omni-perfetto.cfg` Contents

> Used by `perfetto` command in `run.sh`

```console
duration_ms: 3000
write_into_file: true
file_write_period_ms: 3000
flush_period_ms: 3000

buffers {
  size_kb: 102400000
  fill_policy: RING_BUFFER
}

data_sources {
  config {
      name: "track_event"
  }
}
```

### Additional Notes

Omnitrace had to be built from scratch with `OMNITRACE_MAX_THREADS=4096` to complete at least one of the PyTorch runs because it created > 2048 threads (the default max threads in an installer release) and caused omnitrace to abort. However, this absolute restriction on the total number of threads created by a process will eventually be removed (hopefully soon).