### PR TITLE
Dynamic expansion of thread data

### DIFF
--- a/cmake/BuildSettings.cmake
+++ b/cmake/BuildSettings.cmake
@@ -86,7 +86,7 @@ endif()
 #
 add_flag_if_avail(
     "-W" "-Wall" "-Wno-unknown-pragmas" "-Wno-unused-function" "-Wno-ignored-attributes"
-    "-Wno-attributes" "-Wno-missing-field-initializers")
+    "-Wno-attributes" "-Wno-missing-field-initializers" "-Wno-interference-size")
 
 if(OMNITRACE_BUILD_DEBUG)
     add_flag_if_avail("-g3" "-fno-omit-frame-pointer")

--- a/cmake/Formatting.cmake
+++ b/cmake/Formatting.cmake
@@ -64,6 +64,8 @@ if(OMNITRACE_CLANG_FORMAT_EXE
     file(GLOB_RECURSE examples ${PROJECT_SOURCE_DIR}/examples/*.cpp
          ${PROJECT_SOURCE_DIR}/examples/*.c ${PROJECT_SOURCE_DIR}/examples/*.hpp
          ${PROJECT_SOURCE_DIR}/examples/*.h)
+    file(GLOB_RECURSE tests_source ${PROJECT_SOURCE_DIR}/tests/source/*.cpp
+         ${PROJECT_SOURCE_DIR}/tests/source/*.hpp)
     file(GLOB_RECURSE external ${PROJECT_SOURCE_DIR}/examples/lulesh/external/kokkos/*)
     file(
         GLOB_RECURSE
@@ -86,6 +88,7 @@ if(OMNITRACE_CLANG_FORMAT_EXE
         add_custom_target(
             format-omnitrace-source
             ${OMNITRACE_CLANG_FORMAT_EXE} -i ${sources} ${headers} ${examples}
+            ${tests_source}
             COMMENT "[omnitrace] Running C++ formatter ${OMNITRACE_CLANG_FORMAT_EXE}...")
     endif()
 

--- a/examples/fork/fork.cpp
+++ b/examples/fork/fork.cpp
@@ -5,6 +5,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <pthread.h>
+#include <set>
 #include <string>
 #include <sys/wait.h>
 #include <thread>
@@ -24,71 +26,111 @@ print_info(const char* _name)
 int
 run(const char* _name, int nchildren)
 {
-    auto _threads = std::vector<std::thread>{};
+    auto _barrier  = pthread_barrier_t{};
+    auto _threads  = std::vector<std::thread>{};
+    auto _children = std::vector<pid_t>{};
+    _children.resize(nchildren, 0);
+    pthread_barrier_init(&_barrier, nullptr, nchildren + 1);
     for(int i = 0; i < nchildren; ++i)
     {
         omnitrace_user_push_region("launch_child");
-        auto _run = [i, _name]() {
-            pid_t _pid = fork();
-            if(_pid == 0)
+        auto _run = [&_barrier, &_children, i, _name](uint64_t _nsec) {
+            pthread_barrier_wait(&_barrier);
+            _children.at(i) = fork();
+            if(_children.at(i) == 0)
             {
                 // child code
                 print_info(_name);
+                printf("[%s][%i] child job starting...\n", _name, getpid());
                 auto _sleep = [=]() {
-                    std::this_thread::sleep_for(std::chrono::seconds{ i + 1 });
+                    omnitrace_user_push_region("child_process_child_thread");
+                    std::this_thread::sleep_for(std::chrono::seconds{ _nsec });
+                    omnitrace_user_pop_region("child_process_child_thread");
                 };
+                omnitrace_user_push_region("child_process");
                 std::thread{ _sleep }.join();
+                omnitrace_user_push_region("child_process");
+                printf("[%s][%i] child job complete\n", _name, getpid());
                 exit(EXIT_SUCCESS);
             }
+            else
+            {
+                pthread_barrier_wait(&_barrier);
+            }
         };
-        _threads.emplace_back(_run);
+        _threads.emplace_back(_run, i + 1);
         omnitrace_user_pop_region("launch_child");
     }
+
+    // all child threads should start executing their fork once this returns
+    pthread_barrier_wait(&_barrier);
+    // wait for the threads to successfully fork
+    pthread_barrier_wait(&_barrier);
 
     omnitrace_user_push_region("wait_for_children");
 
     int   _status   = 0;
     pid_t _wait_pid = 0;
     // parent waits for all the child processes
-    while((_wait_pid = wait(&_status)) > 0)
+    for(auto& itr : _children)
     {
-        printf("[%s][%i] returned from wait with pid = %i :: ", _name, getpid(),
-               _wait_pid);
-        if(WIFEXITED(_status))
+        while(itr == 0)
+        {}
+        printf("[%s][%i] performing waitpid(%i, ...)\n", _name, getpid(), itr);
+        while((_wait_pid = waitpid(itr, &_status, WUNTRACED | WNOHANG)) <= 0)
         {
-            printf("exited, status=%d\n", WEXITSTATUS(_status));
-        }
-        else if(WIFSIGNALED(_status))
-        {
-            printf("killed by signal %d\n", WTERMSIG(_status));
-        }
-        else if(WIFSTOPPED(_status))
-        {
-            printf("stopped by signal %d\n", WSTOPSIG(_status));
-        }
-        else if(WIFCONTINUED(_status))
-        {
-            printf("continued\n");
-        }
-        else
-        {
-            printf("unknown\n");
+            if(_wait_pid == 0) continue;
+
+            printf("[%s][%i] returned from waitpid(%i) with pid = %i (status = %i) :: ",
+                   _name, getpid(), itr, _wait_pid, _status);
+            if(WIFEXITED(_status))
+            {
+                printf("exited, status=%d\n", WEXITSTATUS(_status));
+            }
+            else if(WIFSIGNALED(_status))
+            {
+                printf("killed by signal %d\n", WTERMSIG(_status));
+            }
+            else if(WIFSTOPPED(_status))
+            {
+                printf("stopped by signal %d\n", WSTOPSIG(_status));
+            }
+            else if(WIFCONTINUED(_status))
+            {
+                printf("continued\n");
+            }
+            else
+            {
+                printf("unknown\n");
+            }
         }
     }
 
+    printf("[%s][%i] joining threads ...\n", _name, getpid());
     for(auto& itr : _threads)
         itr.join();
 
     omnitrace_user_pop_region("wait_for_children");
+
+    printf("[%s][%i] returning (error code: %i) ...\n", _name, getpid(), _status);
     return _status;
 }
 
 int
 main(int argc, char** argv)
 {
-    int _n = 4;
-    if(argc > 1) _n = std::stoi(argv[1]);
+    int _nfork = 4;
+    int _nrep  = 1;
+    if(argc > 1) _nfork = std::stoi(argv[1]);
+    if(argc > 2) _nrep = std::stoi(argv[2]);
 
     print_info(argv[0]);
-    return run(argv[0], _n);
+    for(int i = 0; i < _nrep; ++i)
+    {
+        auto _ec = run(argv[0], _nfork);
+        if(_ec != 0) return _ec;
+    }
+
+    printf("[%s][%i] job complete\n", argv[0], getpid());
+    return EXIT_SUCCESS;
 }

--- a/source/bin/omnitrace-sample/impl.cpp
+++ b/source/bin/omnitrace-sample/impl.cpp
@@ -140,12 +140,6 @@ get_initial_environment()
     auto _mode = get_env<std::string>("OMNITRACE_MODE", "sampling", false);
 
     update_env(_env, "OMNITRACE_USE_SAMPLING", (_mode != "causal"));
-    update_env(_env, "OMNITRACE_CRITICAL_TRACE", false);
-    update_env(_env, "OMNITRACE_USE_PROCESS_SAMPLING", false);
-
-    // update_env(_env, "OMNITRACE_USE_PID", false);
-    // update_env(_env, "OMNITRACE_TIME_OUTPUT", false);
-    // update_env(_env, "OMNITRACE_OUTPUT_PATH", "omnitrace-output/%tag%/%launch_time%");
 
 #if defined(OMNITRACE_USE_ROCTRACER) || defined(OMNITRACE_USE_ROCPROFILER)
     update_env(_env, "HSA_TOOLS_LIB", _dl_libpath);

--- a/source/bin/tests/CMakeLists.txt
+++ b/source/bin/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(OMNITRACE_ABORT_FAIL_REGEX
-    "### ERROR ###|address of faulting memory reference|exiting with non-zero exit code|terminate called after throwing an instance|calling abort.. in |Exit code: [1-9]"
-    CACHE INTERNAL "Regex to catch abnormal exits when a PASS_REGULAR_EXPRESSION is set")
+    "### ERROR ###|unknown-hash=|address of faulting memory reference|exiting with non-zero exit code|terminate called after throwing an instance|calling abort.. in |Exit code: [1-9]"
+    CACHE INTERNAL "Regex to catch abnormal exits when a PASS_REGULAR_EXPRESSION is set"
+          FORCE)
 
 # adds a ctest for executable
 function(OMNITRACE_ADD_BIN_TEST)

--- a/source/lib/common/defines.h.in
+++ b/source/lib/common/defines.h.in
@@ -46,6 +46,17 @@
 #define OMNITRACE_HIP_VERSION_MAJOR @OMNITRACE_HIP_VERSION_MAJOR@
 #define OMNITRACE_HIP_VERSION_MINOR @OMNITRACE_HIP_VERSION_MINOR@
 #define OMNITRACE_HIP_VERSION_PATCH @OMNITRACE_HIP_VERSION_PATCH@
+
+// these can be set via defining the variable in CMake, e.g.:
+//      cmake -D OMNITRACE_CACHELINE_SIZE=N /path/to/source
+// if not defined when configuring cmake, these values fall back to
+// default values set in core/containers/aligned_static_vector.hpp.
+// the OMNITRACE_CACHELINE_SIZE_MIN is used to ensure portability
+#cmakedefine OMNITRACE_CACHELINE_SIZE @OMNITRACE_CACHELINE_SIZE@
+#cmakedefine OMNITRACE_CACHELINE_SIZE_MIN @OMNITRACE_CACHELINE_SIZE_MIN@
+
+// misc definitions which can be configured by cmake to override the defaults
+#cmakedefine OMNITRACE_ROCM_MAX_COUNTERS @OMNITRACE_ROCM_MAX_COUNTERS@
 // clang-format on
 
 #define OMNITRACE_VERSION                                                                \
@@ -87,16 +98,22 @@
 #endif
 // clang-format on
 
-#if !defined(OMNITRACE_MAX_COUNTERS)
-#    define OMNITRACE_MAX_COUNTERS 25
+// in general, we want to make sure the cache line size is not less than
+// 64 bytes (most common cacheline size for x86-64 CPUs) so unless
+// OMNITRACE_CACHELINE_SIZE was explicitly set, we set the min to 64
+// and use the max value of OMNITRACE_CACHELINE_SIZE and
+// OMNITRACE_CACHELINE_SIZE_MIN to assure that false-sharing is well
+// guarded against
+#if !defined(OMNITRACE_CACHELINE_SIZE_MIN)
+#    if defined(OMNITRACE_CACHELINE_SIZE)
+#        define OMNITRACE_CACHELINE_SIZE_MIN OMNITRACE_CACHELINE_SIZE
+#    else
+#        define OMNITRACE_CACHELINE_SIZE_MIN 64
+#    endif
 #endif
 
-#if !defined(OMNITRACE_ROCM_LOOK_AHEAD)
-#    define OMNITRACE_ROCM_LOOK_AHEAD 128
-#endif
-
-#if !defined(OMNITRACE_MAX_ROCM_QUEUES)
-#    define OMNITRACE_MAX_ROCM_QUEUES OMNITRACE_MAX_THREADS
+#if !defined(OMNITRACE_ROCM_MAX_COUNTERS)
+#    define OMNITRACE_ROCM_MAX_COUNTERS 25
 #endif
 
 #define OMNITRACE_ATTRIBUTE(...)    __attribute__((__VA_ARGS__))

--- a/source/lib/core/binary/address_range.cpp
+++ b/source/lib/core/binary/address_range.cpp
@@ -183,7 +183,7 @@ address_range::operator+=(address_range _v)
 hash_value_t
 address_range::hash() const
 {
-    return (is_range()) ? tim::get_combined_hash_id(hash_value_t{ low }, high)
+    return (is_range()) ? tim::get_hash_id(hash_value_t{ low }, high)
                         : hash_value_t{ low };
 }
 }  // namespace binary

--- a/source/lib/core/concepts.hpp
+++ b/source/lib/core/concepts.hpp
@@ -52,6 +52,13 @@ using tim::identity_t;  // NOLINT
 template <typename Tp>
 struct use_placement_new_when_generating_unique_ptr : std::false_type
 {};
+
+template <typename Tp, typename... Args>
+auto
+make_unique(Args&&... args)
+{
+    return unique_ptr_t<Tp>{ new Tp{ std::forward<Args>(args)... } };
+}
 }  // namespace omnitrace
 
 namespace tim

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -293,7 +293,7 @@ configure_settings(bool _init)
     OMNITRACE_CONFIG_SETTING(
         bool, "OMNITRACE_USE_ROCM_SMI",
         "Enable sampling GPU power, temp, utilization, and memory usage", true, "backend",
-        "rocm_smi", "rocm");
+        "rocm_smi", "rocm", "process_sampling");
 
     OMNITRACE_CONFIG_SETTING(
         bool, "OMNITRACE_USE_ROCTX",
@@ -1154,7 +1154,6 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
     {
         set_default_setting_value("OMNITRACE_USE_SAMPLING", true);
         set_default_setting_value("OMNITRACE_USE_PROCESS_SAMPLING", true);
-        _set("OMNITRACE_CRITICAL_TRACE", false);
     }
 
     if(gpu::device_count() == 0)

--- a/source/lib/core/containers/CMakeLists.txt
+++ b/source/lib/core/containers/CMakeLists.txt
@@ -1,7 +1,11 @@
 #
 set(containers_sources)
 
-set(containers_headers ${CMAKE_CURRENT_LIST_DIR}/stable_vector.hpp
-                       ${CMAKE_CURRENT_LIST_DIR}/static_vector.hpp)
+set(containers_headers
+    ${CMAKE_CURRENT_LIST_DIR}/aligned_static_vector.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/c_array.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/operators.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/stable_vector.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/static_vector.hpp)
 
 target_sources(omnitrace-core-library PRIVATE ${containers_sources} ${containers_headers})

--- a/source/lib/core/containers/aligned_static_vector.hpp
+++ b/source/lib/core/containers/aligned_static_vector.hpp
@@ -30,6 +30,7 @@
 #include <array>
 #include <atomic>
 #include <cstdlib>
+#include <new>
 
 namespace omnitrace
 {
@@ -44,7 +45,8 @@ namespace container
 #    endif
 #endif
 
-constexpr std::size_t cacheline_align_v = OMNITRACE_CACHELINE_SIZE;
+constexpr std::size_t cacheline_align_v =
+    std::max<size_t>(OMNITRACE_CACHELINE_SIZE, OMNITRACE_CACHELINE_SIZE_MIN);
 
 template <typename Tp, size_t N, size_t AlignN = cacheline_align_v,
           bool AtomicSizeV = false>

--- a/source/lib/core/containers/aligned_static_vector.hpp
+++ b/source/lib/core/containers/aligned_static_vector.hpp
@@ -1,0 +1,324 @@
+// MIT License
+//
+// Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "core/common.hpp"
+#include "core/containers/operators.hpp"
+#include "core/debug.hpp"
+#include "core/exception.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstdlib>
+
+namespace omnitrace
+{
+namespace container
+{
+#if !defined(OMNITRACE_CACHELINE_SIZE)
+#    ifdef __cpp_lib_hardware_interference_size
+#        define OMNITRACE_CACHELINE_SIZE std::hardware_destructive_interference_size
+#    else
+// 64 bytes on x86-64 │ L1_CACHE_BYTES │ L1_CACHE_SHIFT │ __cacheline_aligned │ ...
+#        define OMNITRACE_CACHELINE_SIZE 64
+#    endif
+#endif
+
+constexpr std::size_t cacheline_align_v = OMNITRACE_CACHELINE_SIZE;
+
+template <typename Tp, size_t N, size_t AlignN = cacheline_align_v,
+          bool AtomicSizeV = false>
+struct aligned_static_vector
+{
+    struct aligned_value_type
+    {
+        alignas(AlignN) Tp value = {};
+    };
+
+    using count_type      = std::conditional_t<AtomicSizeV, std::atomic<size_t>, size_t>;
+    using this_type       = aligned_static_vector<Tp, N>;
+    using const_this_type = const aligned_static_vector<Tp, N>;
+    using value_type      = Tp;
+    using array_type      = std::array<aligned_value_type, N>;
+    using reference       = value_type&;
+    using const_reference = const value_type&;
+    using pointer         = value_type*;
+    using const_pointer   = const value_type*;
+    using size_type       = size_t;
+    using difference_type = std::ptrdiff_t;
+
+    aligned_static_vector()                                 = default;
+    aligned_static_vector(const aligned_static_vector&)     = default;
+    aligned_static_vector(aligned_static_vector&&) noexcept = default;
+    aligned_static_vector& operator=(const aligned_static_vector&) = default;
+    aligned_static_vector& operator=(aligned_static_vector&&) noexcept = default;
+
+    aligned_static_vector(size_t _n, Tp _v = {});
+
+    aligned_static_vector& operator=(std::initializer_list<Tp>&& _v);
+    aligned_static_vector& operator=(std::pair<std::array<Tp, N>, size_t>&&);
+
+    template <typename... Args>
+    value_type& emplace_back(Args&&... _v);
+
+    template <typename Up>
+    decltype(auto) push_back(Up&& _v)
+    {
+        return emplace_back(Tp{ std::forward<Up>(_v) });
+    }
+
+    void pop_back() { --m_size; }
+
+    void clear();
+    void reserve(size_t) noexcept {}
+    void shrink_to_fit() noexcept {}
+    auto capacity() noexcept { return N; }
+
+    size_t size() const { return m_size; }
+    bool   empty() const { return (size() == 0); }
+
+    reference       operator[](size_t _idx) { return m_data[_idx].value; }
+    const_reference operator[](size_t _idx) const { return m_data[_idx].value; }
+
+    reference       at(size_t _idx) { return m_data.at(_idx).value; }
+    const_reference at(size_t _idx) const { return m_data.at(_idx).value; }
+
+    reference       front() { return m_data.front().value; }
+    const_reference front() const { return m_data.front().value; }
+    reference       back() { return *(m_data.begin() + size() - 1).value; }
+    const_reference back() const { return *(m_data.begin() + size() - 1).value; }
+
+    void swap(this_type& _v);
+
+    friend void swap(this_type& _lhs, this_type& _rhs) { _lhs.swap(_rhs); }
+
+    template <typename ContainerT>
+    struct iterator_base
+    {
+        iterator_base(ContainerT* c = nullptr, size_type i = 0)
+        : m_container(c)
+        , m_index(i)
+        {}
+
+        iterator_base& operator+=(size_type i)
+        {
+            m_index += i;
+            return *this;
+        }
+        iterator_base& operator-=(size_type i)
+        {
+            m_index -= i;
+            return *this;
+        }
+        iterator_base& operator++()
+        {
+            ++m_index;
+            return *this;
+        }
+        iterator_base& operator--()
+        {
+            --m_index;
+            return *this;
+        }
+
+        difference_type operator-(const iterator_base& itr)
+        {
+            assert(m_container == itr.m_container);
+            return m_index - itr.m_index;
+        }
+
+        bool operator<(const iterator_base& itr) const
+        {
+            assert(m_container == itr.m_container);
+            return m_index < itr.m_index;
+        }
+        bool operator==(const iterator_base& itr) const
+        {
+            return m_container == itr.m_container && m_index == itr.m_index;
+        }
+
+    protected:
+        ContainerT* m_container;
+        size_type   m_index;
+    };
+
+public:
+    struct const_iterator;
+
+    struct iterator
+    : public iterator_base<this_type>
+    , public random_access_iterator_helper<iterator, value_type>
+    {
+        using iterator_base<this_type>::iterator_base;
+        friend struct const_iterator;
+
+        reference operator*() { return (*this->m_container)[this->m_index]; }
+    };
+
+    struct const_iterator
+    : public iterator_base<const_this_type>
+    , public random_access_iterator_helper<const_iterator, const value_type>
+    {
+        using iterator_base<const_this_type>::iterator_base;
+
+        const_iterator(const iterator& itr)
+        : iterator_base<const_this_type>(itr.m_container, itr.m_index)
+        {}
+
+        const_reference operator*() const { return (*this->m_container)[this->m_index]; }
+
+        bool operator==(const const_iterator& itr) const
+        {
+            return iterator_base<const_this_type>::operator==(itr);
+        }
+
+        friend bool operator==(const iterator& l, const const_iterator& r)
+        {
+            return r == l;
+        }
+    };
+
+    iterator       begin() noexcept { return { this, 0 }; }
+    const_iterator begin() const noexcept { return { this, 0 }; }
+    const_iterator cbegin() const noexcept { return begin(); }
+
+    iterator       end() noexcept { return { this, size() }; }
+    const_iterator end() const noexcept { return { this, size() }; }
+    const_iterator cend() const noexcept { return end(); }
+
+private:
+    count_type m_size = count_type{ 0 };
+    array_type m_data = {};
+};
+
+template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::aligned_static_vector(size_t _n, Tp _v)
+{
+    m_data.fill(_v);
+    if constexpr(AtomicSizeV)
+        m_size.store(_n);
+    else
+        m_size = _n;
+}
+
+template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>&
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::operator=(
+    std::initializer_list<Tp>&& _v)
+{
+    if(OMNITRACE_UNLIKELY(_v.size() > N))
+    {
+        throw exception<std::out_of_range>(
+            std::string{ "aligned_static_vector::operator=(initializer_list) size > " } +
+            std::to_string(N));
+    }
+
+    clear();
+    for(auto&& itr : _v)
+        m_data[m_size++] = itr;
+    return *this;
+}
+
+template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>&
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::operator=(
+    std::pair<std::array<Tp, N>, size_t>&& _v)
+{
+    if constexpr(AtomicSizeV) m_size.store(0);
+
+    for(size_t i = 0; i < N; ++i)
+        m_data[i].value = std::move(_v.first[i]);
+
+    if constexpr(AtomicSizeV)
+        m_size.store(_v.second);
+    else
+        m_size = _v.second;
+
+    return *this;
+}
+
+template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
+void
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::clear()
+{
+    if constexpr(AtomicSizeV)
+        m_size.store(0);
+    else
+        m_size = 0;
+}
+
+template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
+void
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::swap(this_type& _v)
+{
+    if constexpr(AtomicSizeV)
+    {
+        auto _t_size = m_size;
+        auto _v_size = _v.m_size;
+        std::swap(m_data, _v.m_data);
+        m_size.store(_v_size);
+        _v.m_size.store(_t_size);
+    }
+    else
+    {
+        std::swap(m_size, _v.m_size);
+        std::swap(m_data, _v.m_data);
+    }
+}
+
+template <typename Tp, size_t N, size_t AlignN, bool AtomicSizeV>
+template <typename... Args>
+Tp&
+aligned_static_vector<Tp, N, AlignN, AtomicSizeV>::emplace_back(Args&&... _v)
+{
+    auto _idx = m_size++;
+    if(_idx >= N)
+    {
+        throw exception<std::out_of_range>(
+            std::string{ "aligned_static_vector::emplace_back - reached capacity " } +
+            std::to_string(N));
+    }
+
+    if constexpr(sizeof...(Args) > 0)
+    {
+        if constexpr(std::is_assignable<Tp, decltype(std::forward<Args>(_v))...>::value)
+            m_data[_idx].value = { std::forward<Args>(_v)... };
+        else if constexpr(std::is_constructible<Tp, decltype(std::forward<Args>(
+                                                        _v))...>::value)
+            m_data[_idx].value = Tp{ std::forward<Args>(_v)... };
+        else
+            static_assert(
+                sizeof...(Args) == 0,
+                "Error! Tp is not assignable or constructible with provided args");
+    }
+    else
+    {
+        // _v... expands to nothing but is used to suppress unused variable warnings
+        m_data[_idx].value = { _v... };
+    }
+
+    return m_data[_idx].value;
+}
+
+}  // namespace container
+}  // namespace omnitrace

--- a/source/lib/core/containers/static_vector.hpp
+++ b/source/lib/core/containers/static_vector.hpp
@@ -40,9 +40,16 @@ namespace container
 template <typename Tp, size_t N, bool AtomicSizeV = false>
 struct static_vector
 {
-    using count_type = std::conditional_t<AtomicSizeV, std::atomic<size_t>, size_t>;
-    using this_type  = static_vector<Tp, N>;
-    using value_type = Tp;
+    using count_type      = std::conditional_t<AtomicSizeV, std::atomic<size_t>, size_t>;
+    using this_type       = static_vector<Tp, N>;
+    using value_type      = Tp;
+    using array_type      = std::array<Tp, N>;
+    using reference       = value_type&;
+    using const_reference = const value_type&;
+    using pointer         = value_type*;
+    using const_pointer   = const value_type*;
+    using size_type       = size_t;
+    using difference_type = std::ptrdiff_t;
 
     static_vector()                         = default;
     static_vector(const static_vector&)     = default;

--- a/source/lib/core/debug.hpp
+++ b/source/lib/core/debug.hpp
@@ -635,9 +635,10 @@ as_hex<void*>(void*, size_t);
 
 #define OMNITRACE_REQUIRE(...) TIMEMORY_REQUIRE(__VA_ARGS__)
 #define OMNITRACE_PREFER(COND)                                                           \
-    (OMNITRACE_LIKELY(COND))                         ? ::tim::log::base()                \
-    : (::omnitrace::get_is_continuous_integration()) ? TIMEMORY_FATAL                    \
-                                                     : TIMEMORY_WARNING
+    ((OMNITRACE_LIKELY(COND))                                                            \
+         ? ::tim::log::base()                                                            \
+         : ((::omnitrace::get_is_continuous_integration()) ? TIMEMORY_FATAL              \
+                                                           : TIMEMORY_WARNING))
 
 //--------------------------------------------------------------------------------------//
 //

--- a/source/lib/omnitrace/library/causal/components/progress_point.cpp
+++ b/source/lib/omnitrace/library/causal/components/progress_point.cpp
@@ -60,8 +60,7 @@ get_progress_map(int64_t _tid)
 auto&
 get_progress_allocator(int64_t _tid)
 {
-    static auto& _v = thread_data<progress_allocator_t>::instances(construct_on_init{});
-    return _v.at(_tid);
+    return thread_data<progress_allocator_t>::instance(construct_on_thread{ _tid });
 }
 }  // namespace
 

--- a/source/lib/omnitrace/library/causal/sampling.cpp
+++ b/source/lib/omnitrace/library/causal/sampling.cpp
@@ -573,7 +573,7 @@ post_process()
 
     block_samples();
 
-    for(size_t i = 0; i < max_supported_threads; ++i)
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
     {
         auto& _causal = get_causal_sampler(i);
         if(_causal) _causal->stop();
@@ -586,7 +586,7 @@ post_process()
     auto _allocator = get_causal_sampler_allocator(false);
     if(_allocator) _allocator->flush();
 
-    for(size_t i = 0; i < max_supported_threads; ++i)
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
     {
         auto& _causal = get_causal_sampler(i);
         auto  _causal_data =
@@ -595,7 +595,7 @@ post_process()
         if(!_causal_data.empty()) post_process_causal(i, _causal_data);
     }
 
-    for(size_t i = 0; i < max_supported_threads; ++i)
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
     {
         get_causal_sampler(i).reset();
 

--- a/source/lib/omnitrace/library/components/backtrace.cpp
+++ b/source/lib/omnitrace/library/components/backtrace.cpp
@@ -121,6 +121,7 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
         if(_keep_internal) return 1;
         if(_lbl.find("omnitrace_main") != _npos) return 0;
         if(_lbl.find("omnitrace::") != _npos) return 0;
+        if(_lbl.find("tim::openmp::") != _npos) return -1;
         if(_lbl.find("tim::") != _npos) return 0;
         if(_lbl.find("DYNINST_") != _npos) return 0;
         if(_lbl.find("omnitrace_") != _npos) return -1;

--- a/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
@@ -33,6 +33,7 @@
 #include "library/sampling.hpp"
 #include "library/thread_data.hpp"
 #include "library/thread_info.hpp"
+#include "library/tracing.hpp"
 
 #include <timemory/backends/threading.hpp>
 #include <timemory/components/macros.hpp>
@@ -367,6 +368,8 @@ pthread_create_gotcha::configure()
             0, int, pthread_t*, const pthread_attr_t*, void* (*) (void*), void*>(
             "pthread_create");
     };
+
+    tim::hash::add_hash_id("start_thread");
 }
 
 void
@@ -386,6 +389,8 @@ pthread_create_gotcha::shutdown()
     {
         if(itr.second) ++_ndangling;
     }
+
+    tracing::copy_timemory_hash_ids();
 
     // enable the signal handler for when the timeout is reached
     struct sigaction _action = {};

--- a/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_create_gotcha.cpp
@@ -23,6 +23,7 @@
 #include "library/components/pthread_create_gotcha.hpp"
 #include "core/config.hpp"
 #include "core/debug.hpp"
+#include "core/locking.hpp"
 #include "core/state.hpp"
 #include "core/utility.hpp"
 #include "library/causal/delay.hpp"
@@ -36,10 +37,13 @@
 #include <timemory/backends/threading.hpp>
 #include <timemory/components/macros.hpp>
 #include <timemory/components/timing/wall_clock.hpp>
+#include <timemory/hash/types.hpp>
 #include <timemory/mpl/types.hpp>
 #include <timemory/sampling/allocator.hpp>
+#include <timemory/units.hpp>
 #include <timemory/utility/types.hpp>
 
+#include <csignal>
 #include <ostream>
 #include <pthread.h>
 #include <utility>
@@ -74,11 +78,12 @@ auto  bundles_dtor  = scope::destructor{ []() {
 
 template <typename... Args>
 inline void
-start_bundle(bundle_t& _bundle, Args&&... _args)
+start_bundle(bundle_t& _bundle, int64_t _tid, Args&&... _args)
 {
     if(!get_use_timemory() && !get_use_perfetto()) return;
     trait::runtime_enabled<comp::roctracer_data>::set(get_use_roctracer());
-    OMNITRACE_BASIC_VERBOSE_F(3, "starting bundle '%s'...\n", _bundle.key().c_str());
+    OMNITRACE_BASIC_VERBOSE_F(3, "starting bundle '%s' in thread %li...\n",
+                              _bundle.key().c_str(), _tid);
     if constexpr(sizeof...(Args) > 0)
     {
         const char* _name = nullptr;
@@ -94,7 +99,7 @@ start_bundle(bundle_t& _bundle, Args&&... _args)
     }
     if(get_use_timemory())
     {
-        _bundle.push();
+        _bundle.push(_tid);
         _bundle.start();
     }
 }
@@ -139,7 +144,11 @@ stop_bundle(bundle_t& _bundle, int64_t _tid, Args&&... _args)
     }
 }
 
-std::set<pthread_create_gotcha::native_handle_t> native_handles = {};
+using native_handle_set_t = std::set<pthread_create_gotcha::native_handle_t>;
+
+auto native_handles          = native_handle_set_t{};
+auto internal_native_handles = native_handle_set_t{};
+auto native_handles_mutex    = locking::atomic_mutex{};
 }  // namespace
 
 //--------------------------------------------------------------------------------------//
@@ -210,6 +219,13 @@ pthread_create_gotcha::wrapper::operator()() const
 
     auto _active = (get_state() == ::omnitrace::State::Active && bundles != nullptr &&
                     bundles_mutex != nullptr);
+
+    if(m_config.offset)
+    {
+        auto _lk = locking::atomic_lock{ native_handles_mutex };
+        internal_native_handles.emplace(pthread_self());
+    }
+
     if(_active && !_coverage && !m_config.offset)
     {
         _tid = _info->index_data->sequent_value;
@@ -220,13 +236,13 @@ pthread_create_gotcha::wrapper::operator()() const
         threading::set_thread_name(TIMEMORY_JOIN(" ", "Thread", _tid).c_str());
         auto _manager = tim::manager::instance();
         if(_manager) _manager->initialize();
-        if(!thread_bundle_data_t::instances().at(_tid))
+        if(!thread_bundle_data_t::get()->at(_tid))
         {
             thread_data<thread_bundle_t>::construct(
                 TIMEMORY_JOIN('/', "omnitrace/process", process::get_id(), "thread",
                               _tid),
                 quirk::config<quirk::auto_start>{});
-            thread_bundle_data_t::instances().at(_tid)->start();
+            thread_bundle_data_t::get()->at(_tid)->start();
         }
         if(bundles && bundles_mutex)
         {
@@ -234,7 +250,7 @@ pthread_create_gotcha::wrapper::operator()() const
             _bundle = bundles->emplace(_tid, std::make_shared<bundle_t>("start_thread"))
                           .first->second;
         }
-        if(_bundle) start_bundle(*_bundle);
+        if(_bundle) start_bundle(*_bundle, _tid);
         get_cpu_cid_stack(_tid, m_config.parent_tid);
         if(m_config.enable_causal)
         {
@@ -299,19 +315,48 @@ pthread_create_gotcha::wrapper::wrap(void* _arg)
     wrapper* _wrapper = static_cast<wrapper*>(_arg);
 
     // store the handle
-    native_handles.emplace(_self);
+    {
+        auto _lk = locking::atomic_lock{ native_handles_mutex };
+        native_handles.emplace(_self);
+    }
+
+    static thread_local auto _remover = scope::destructor{ []() {
+        if(get_state() >= omnitrace::State::Finalized) return;
+        // remove the handle even if original function aborts
+        auto                 _lk      = locking::atomic_lock{ native_handles_mutex };
+        native_handles.erase(pthread_self());
+    } };
+    (void) _remover;
 
     // execute the original function
     void* _ret = (*_wrapper)();
 
     // remove the handle
-    if(::pthread_equal(_self, pthread_self()) == 0) native_handles.erase(_self);
+    if(::pthread_equal(_self, pthread_self()) == 0)
+    {
+        auto _lk = locking::atomic_lock{ native_handles_mutex };
+        native_handles.erase(_self);
+    }
 
     // eliminate memory leak
     if(_ret != _arg) delete _wrapper;
 
     return _ret;
 }
+
+namespace
+{
+const auto shutdown_signal_v = SIGRTMAX - 1;
+
+size_t shutdown_signals_delivered = 0;
+
+void
+pthread_create_gotcha_shutdown_handler(int)
+{
+    pthread_create_gotcha::shutdown(threading::get_id());
+    ++shutdown_signals_delivered;
+}
+}  // namespace
 
 void
 pthread_create_gotcha::configure()
@@ -335,8 +380,65 @@ pthread_create_gotcha::shutdown()
 
     if(!bundles_mutex || !bundles) return;
 
+    unsigned long _ndangling = 0;
+
+    for(const auto& itr : *bundles)
+    {
+        if(itr.second) ++_ndangling;
+    }
+
+    // enable the signal handler for when the timeout is reached
+    struct sigaction _action = {};
+    struct sigaction _former = {};
+
+    memset(&_action, 0, sizeof(_action));
+    memset(&_former, 0, sizeof(_former));
+    sigemptyset(&_action.sa_mask);
+    sigemptyset(&_former.sa_mask);
+
+    _action.sa_flags   = SA_RESTART;
+    _action.sa_handler = pthread_create_gotcha_shutdown_handler;
+    // activate signal handler
+    sigaction(shutdown_signal_v, &_action, &_former);
+
+    size_t _expected_shutdown_signals_delivered = 0;
+    {
+        auto _lk = locking::atomic_lock{ native_handles_mutex };
+        for(auto itr : native_handles)
+        {
+            // skip sending signals to internal threads
+            if(internal_native_handles.count(itr) != 0) continue;
+            if(pthread_equal(pthread_self(), itr) == 0 && pthread_equal(itr, itr) != 0)
+            {
+                ::pthread_kill(itr, shutdown_signal_v);
+                ++_expected_shutdown_signals_delivered;
+            }
+        }
+
+        auto           _nattempt    = 0U;
+        constexpr auto nmax_attempt = 20U;
+        while(shutdown_signals_delivered < _expected_shutdown_signals_delivered &&
+              _nattempt++ < nmax_attempt)
+        {
+            std::this_thread::yield();
+            std::this_thread::sleep_for(std::chrono::milliseconds{ 50 });
+        }
+
+        OMNITRACE_CI_BASIC_FAIL(
+            shutdown_signals_delivered != _expected_shutdown_signals_delivered,
+            "Number of signals delivered (%zu) != expected number of signals delievered "
+            "(%zu)",
+            shutdown_signals_delivered, _expected_shutdown_signals_delivered);
+    }
+
+    // restore existing signal handler
+    sigaction(shutdown_signal_v, &_former, nullptr);
+
+    // subtract the bundles that had signals delivered
+    _ndangling -= shutdown_signals_delivered;
+
+    // stop any remaining dangling bundles on this thread
     std::unique_lock<std::mutex> _lk{ *bundles_mutex };
-    unsigned long                _ndangling = 0;
     for(auto itr : *bundles)
     {
         if(itr.second)
@@ -480,7 +582,8 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
     if(_use_bundle)
     {
         _bundle = bundle_t{ "pthread_create" };
-        start_bundle(*_bundle, audit::incoming{}, thread, attr, func, arg);
+        start_bundle(*_bundle, _info->index_data->sequent_value, audit::incoming{},
+                     thread, attr, func, arg);
     }
 
     // threads must process their delays before creating a new thread

--- a/source/lib/omnitrace/library/components/pthread_gotcha.cpp
+++ b/source/lib/omnitrace/library/components/pthread_gotcha.cpp
@@ -97,7 +97,7 @@ pthread_gotcha::shutdown()
     if(is_configured)
     {
         ::omnitrace::component::pthread_mutex_gotcha::shutdown();
-        // ::omnitrace::component::pthread_create_gotcha::shutdown();
+        ::omnitrace::component::pthread_create_gotcha::shutdown();
         is_configured = false;
     }
 }

--- a/source/lib/omnitrace/library/components/rocprofiler.cpp
+++ b/source/lib/omnitrace/library/components/rocprofiler.cpp
@@ -61,8 +61,7 @@ unique_ptr_t<rocm_data_t>&
 rocm_data(int64_t _tid)
 {
     using thread_data_t = thread_data<rocm_data_t, rocm_event>;
-    static auto& _v     = thread_data_t::instances(construct_on_init{});
-    return _v.at(_tid);
+    return thread_data_t::instance(construct_on_thread{ _tid });
 }
 
 rocm_event::rocm_event(uint32_t _dev, uint32_t _thr, uint32_t _queue,

--- a/source/lib/omnitrace/library/components/rocprofiler.hpp
+++ b/source/lib/omnitrace/library/components/rocprofiler.hpp
@@ -57,7 +57,7 @@ using rocm_feature_value = std::variant<uint32_t, float, uint64_t, double>;
 
 struct rocm_counter
 {
-    std::array<rocm_metric_type, OMNITRACE_MAX_COUNTERS> counters;
+    std::array<rocm_metric_type, OMNITRACE_ROCM_MAX_COUNTERS> counters;
 };
 
 struct rocm_event

--- a/source/lib/omnitrace/library/components/roctracer.cpp
+++ b/source/lib/omnitrace/library/components/roctracer.cpp
@@ -30,6 +30,7 @@
 #include "library/roctracer.hpp"
 #include "library/runtime.hpp"
 #include "library/thread_data.hpp"
+#include "library/thread_info.hpp"
 
 #include <roctracer.h>
 
@@ -265,7 +266,7 @@ roctracer::setup(void* table, bool on_load_trace)
         itr.second();
 
     // make sure all async callbacks are allocated
-    for(size_t i = 0; i < max_supported_threads; ++i)
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
         hip_exec_activity_callbacks(i);
 
     OMNITRACE_VERBOSE_F(1, "roctracer is setup\n");
@@ -286,9 +287,9 @@ roctracer::shutdown()
     OMNITRACE_VERBOSE_F(1, "shutting down roctracer...\n");
 
     OMNITRACE_VERBOSE_F(2, "executing hip_exec_activity_callbacks(0..%zu)\n",
-                        max_supported_threads);
+                        thread_info::get_peak_num_threads());
     // make sure all async operations are executed
-    for(size_t i = 0; i < max_supported_threads; ++i)
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
         hip_exec_activity_callbacks(i);
 
     // callback for hsa

--- a/source/lib/omnitrace/library/coverage.cpp
+++ b/source/lib/omnitrace/library/coverage.cpp
@@ -87,8 +87,7 @@ get_coverage_data()
 auto&
 get_coverage_count(int64_t _tid = tim::threading::get_id())
 {
-    static auto& _v = coverage_thread_data::instances(construct_on_init{});
-    return _v.at(_tid);
+    return coverage_thread_data::instance(construct_on_thread{ _tid });
 }
 }  // namespace
 

--- a/source/lib/omnitrace/library/critical_trace.cpp
+++ b/source/lib/omnitrace/library/critical_trace.cpp
@@ -92,16 +92,8 @@ template <typename Arg0, typename Arg1, typename... Args>
 size_t
 get_combined_hash(Arg0&& _zero, Arg1&& _one, Args&&... _args)
 {
-    size_t _hash = tim::hash::get_combined_hash_id(std::forward<Arg0>(_zero),
-                                                   std::forward<Arg1>(_one));
-    if constexpr(sizeof...(_args) == 0)
-    {
-        return _hash;
-    }
-    else
-    {
-        return get_combined_hash(_hash, std::forward<Args>(_args)...);
-    }
+    return tim::hash::get_hash_id(std::forward<Arg0>(_zero), std::forward<Arg1>(_one),
+                                  std::forward<Args>(_args)...);
 }
 }  // namespace
 
@@ -386,15 +378,15 @@ get_update_frequency()
 unique_ptr_t<call_chain>&
 get(int64_t _tid)
 {
-    static auto&             _v    = thread_data<call_chain>::instances();
+    static auto*             _v    = thread_data<call_chain>::get();
     static thread_local auto _once = [_tid]() {
-        if(!_v.at(0)) _v.at(0) = unique_ptr_t<call_chain>{ new call_chain{} };
-        if(!_v.at(_tid)) _v.at(_tid) = unique_ptr_t<call_chain>{ new call_chain{} };
-        if(_tid > 0) *_v.at(_tid) = *_v.at(0);
+        if(!_v->at(0)) _v->at(0) = unique_ptr_t<call_chain>{ new call_chain{} };
+        if(!_v->at(_tid)) _v->at(_tid) = unique_ptr_t<call_chain>{ new call_chain{} };
+        if(_tid > 0) *_v->at(_tid) = *_v->at(0);
         return true;
     }();
     (void) _once;
-    return _v.at(_tid);
+    return _v->at(_tid);
 }
 
 void

--- a/source/lib/omnitrace/library/ompt.cpp
+++ b/source/lib/omnitrace/library/ompt.cpp
@@ -92,6 +92,7 @@ shutdown()
         trait::runtime_enabled<ompt_toolset_t>::set(false);
         trait::runtime_enabled<ompt_context_t>::set(false);
         comp::user_ompt_bundle::reset();
+        pthread_gotcha::shutdown();
         // call the OMPT finalize callback
         if(f_finalize) (*f_finalize)();
     }

--- a/source/lib/omnitrace/library/rocm_smi.cpp
+++ b/source/lib/omnitrace/library/rocm_smi.cpp
@@ -164,7 +164,7 @@ config()
     {
         if(data::device_list.count(i) > 0)
         {
-            _bundle_data.at(i) = &sampler_instances::instances().at(i);
+            _bundle_data.at(i) = &sampler_instances::get()->at(i);
             if(!*_bundle_data.at(i))
                 *_bundle_data.at(i) = unique_ptr_t<bundle_t>{ new bundle_t{} };
         }
@@ -239,7 +239,7 @@ data::post_process(uint32_t _dev_id)
 
     if(device_count < _dev_id) return;
 
-    auto&       _rocm_smi_v = sampler_instances::instances().at(_dev_id);
+    auto&       _rocm_smi_v = sampler_instances::get()->at(_dev_id);
     auto        _rocm_smi   = (_rocm_smi_v) ? *_rocm_smi_v : std::deque<rocm_smi::data>{};
     const auto& _thread_info = thread_info::get(0, InternalTID);
 

--- a/source/lib/omnitrace/library/thread_deleter.cpp
+++ b/source/lib/omnitrace/library/thread_deleter.cpp
@@ -31,7 +31,7 @@
 
 namespace omnitrace
 {
-template struct component_bundle_cache<instrumentation_bundle_t>;
+template struct component_bundle_cache_impl<instrumentation_bundle_t>;
 
 void
 thread_deleter<void>::operator()() const

--- a/source/lib/omnitrace/library/thread_info.hpp
+++ b/source/lib/omnitrace/library/thread_info.hpp
@@ -109,6 +109,7 @@ struct thread_info
     std::string as_string() const;
 
     static bool                              exists();
+    static size_t                            get_peak_num_threads();
     static const std::optional<thread_info>& init(bool _offset = false);
     static const std::optional<thread_info>& get();
     static const std::optional<thread_info>& get(native_handle_t&);

--- a/source/lib/omnitrace/library/tracing.cpp
+++ b/source/lib/omnitrace/library/tracing.cpp
@@ -21,14 +21,42 @@
 // SOFTWARE.
 
 #include "library/tracing.hpp"
+#include "core/concepts.hpp"
 #include "core/config.hpp"
 #include "core/state.hpp"
+#include "library/thread_data.hpp"
 #include "library/thread_info.hpp"
+
+#include <timemory/hash/types.hpp>
+#include <timemory/process/threading.hpp>
 
 namespace omnitrace
 {
 namespace tracing
 {
+namespace
+{
+tim::hash_map_ptr_t&
+get_timemory_hash_ids(int64_t _tid = threading::get_id());
+
+tim::hash_alias_ptr_t&
+get_timemory_hash_aliases(int64_t _tid = threading::get_id());
+
+tim::hash_map_ptr_t&
+get_timemory_hash_ids(int64_t _tid)
+{
+    return thread_data<identity<tim::hash_map_ptr_t>>::instance(
+        construct_on_thread{ _tid });
+}
+
+tim::hash_alias_ptr_t&
+get_timemory_hash_aliases(int64_t _tid)
+{
+    return thread_data<identity<tim::hash_alias_ptr_t>>::instance(
+        construct_on_thread{ _tid });
+}
+}  // namespace
+
 bool debug_push = tim::get_env("OMNITRACE_DEBUG_PUSH", false) || get_debug_env();
 bool debug_pop  = tim::get_env("OMNITRACE_DEBUG_POP", false) || get_debug_env();
 bool debug_mark = tim::get_env("OMNITRACE_DEBUG_MARK", false) || get_debug_env();
@@ -41,19 +69,43 @@ get_perfetto_track_uuids()
     return _v;
 }
 
-tim::hash_map_ptr_t&
-get_timemory_hash_ids(int64_t _tid)
+void
+copy_timemory_hash_ids()
 {
-    static auto _v = std::array<tim::hash_map_ptr_t, omnitrace::max_supported_threads>{};
-    return _v.at(_tid);
-}
+    // copy these over so that all hashes are known
+    auto& _hmain = tim::hash::get_main_hash_ids();
+    auto& _amain = tim::hash::get_main_hash_aliases();
+    OMNITRACE_REQUIRE(_hmain != nullptr) << "no main timemory hash ids";
+    OMNITRACE_REQUIRE(_amain != nullptr) << "no main timemory hash aliases";
 
-tim::hash_alias_ptr_t&
-get_timemory_hash_aliases(int64_t _tid)
-{
-    static auto _v =
-        std::array<tim::hash_alias_ptr_t, omnitrace::max_supported_threads>{};
-    return _v.at(_tid);
+    // combine all the hash and alias info into one container
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
+    {
+        auto& _hitr = get_timemory_hash_ids(i);
+        auto& _aitr = get_timemory_hash_aliases(i);
+
+        if(_hitr)
+        {
+            for(const auto& itr : *_hitr)
+                _hmain->emplace(itr.first, itr.second);
+        }
+        if(_aitr)
+        {
+            for(auto itr : *_aitr)
+                _amain->emplace(itr.first, itr.second);
+        }
+    }
+
+    // distribute the contents of that combined container to each thread-specific
+    // container
+    for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
+    {
+        auto& _hitr = get_timemory_hash_ids(i);
+        auto& _aitr = get_timemory_hash_aliases(i);
+
+        if(_hitr) *_hitr = *_hmain;
+        if(_aitr) *_aitr = *_amain;
+    }
 }
 
 std::vector<std::function<void()>>&
@@ -94,15 +146,29 @@ thread_init()
     if(get_thread_state() == ThreadState::Disabled) return;
 
     static thread_local auto _thread_setup = []() {
-        if(threading::get_id() > 0)
-            threading::set_thread_name(JOIN(" ", "Thread", threading::get_id()).c_str());
-        thread_data<thread_bundle_t>::construct(JOIN('/', "omnitrace/process",
-                                                     process::get_id(), "thread",
-                                                     threading::get_id()),
-                                                quirk::config<quirk::auto_start>{});
+        const auto& _tinfo = thread_info::init();
+        auto _tidx = (_tinfo && _tinfo->index_data) ? _tinfo->index_data->sequent_value
+                                                    : threading::get_id();
+
+        OMNITRACE_REQUIRE(_tidx >= 0)
+            << "thread setup failed. thread info not initialized: " << [&_tinfo]() {
+                   if(_tinfo) return JOIN("", *_tinfo);
+                   return std::string{ "no thread_info" };
+               }();
+
+        if(_tidx > 0) threading::set_thread_name(JOIN(" ", "Thread", _tidx).c_str());
+        thread_data<thread_bundle_t>::construct(
+            JOIN('/', "omnitrace/process", process::get_id(), "thread", _tidx),
+            quirk::config<quirk::auto_start>{});
         // save the hash maps
-        get_timemory_hash_ids()     = tim::get_hash_ids();
-        get_timemory_hash_aliases() = tim::get_hash_aliases();
+        get_timemory_hash_ids(_tidx)     = tim::get_hash_ids();
+        get_timemory_hash_aliases(_tidx) = tim::get_hash_aliases();
+
+        OMNITRACE_REQUIRE(get_timemory_hash_ids(_tidx) != nullptr)
+            << "no timemory hash ids pointer for thread " << _tidx;
+        OMNITRACE_REQUIRE(get_timemory_hash_aliases(_tidx) != nullptr)
+            << "no timemory hash aliases pointer for thread " << _tidx;
+
         record_thread_start_time();
         return true;
     }();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,3 +24,5 @@ include(${CMAKE_CURRENT_LIST_DIR}/omnitrace-overflow-tests.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/omnitrace-annotate-tests.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/omnitrace-causal-tests.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/omnitrace-python-tests.cmake)
+
+add_subdirectory(source)

--- a/tests/omnitrace-causal-tests.cmake
+++ b/tests/omnitrace-causal-tests.cmake
@@ -127,6 +127,12 @@ causal_e2e_args_and_validation(_causal_fast_func fast-func "-F" "cpu_fast_func" 
 causal_e2e_args_and_validation(_causal_line_100 line-100 "-S" "causal.cpp:100" 10 20 20 5)
 causal_e2e_args_and_validation(_causal_line_110 line-110 "-S" "causal.cpp:110" 0 0 0 5)
 
+if(OMNITRACE_BUILD_NUMBER GREATER 1)
+    set(_causal_e2e_environment)
+else()
+    set(_causal_e2e_environment "OMNITRACE_VERBOSE=0")
+endif()
+
 omnitrace_add_causal_test(
     SKIP_BASELINE
     NAME cpu-omni-slow-func-e2e
@@ -138,6 +144,7 @@ omnitrace_add_causal_test(
     CAUSAL_VALIDATE_ARGS ${_causal_slow_func_valid}
     CAUSAL_PASS_REGEX
         "Starting causal experiment #1(.*)causal/experiments.json(.*)causal/experiments.coz"
+    ENVIRONMENT "${_causal_e2e_environment}"
     PROPERTIES PROCESSORS 2 PROCESSOR_AFFINITY OFF)
 
 omnitrace_add_causal_test(
@@ -151,6 +158,7 @@ omnitrace_add_causal_test(
     CAUSAL_VALIDATE_ARGS ${_causal_fast_func_valid}
     CAUSAL_PASS_REGEX
         "Starting causal experiment #1(.*)causal/experiments.json(.*)causal/experiments.coz"
+    ENVIRONMENT "${_causal_e2e_environment}"
     PROPERTIES PROCESSORS 2 PROCESSOR_AFFINITY OFF)
 
 omnitrace_add_causal_test(
@@ -164,6 +172,7 @@ omnitrace_add_causal_test(
     CAUSAL_VALIDATE_ARGS ${_causal_line_100_valid}
     CAUSAL_PASS_REGEX
         "Starting causal experiment #1(.*)causal/experiments.json(.*)causal/experiments.coz"
+    ENVIRONMENT "${_causal_e2e_environment}"
     PROPERTIES PROCESSORS 2 PROCESSOR_AFFINITY OFF)
 
 omnitrace_add_causal_test(
@@ -177,4 +186,5 @@ omnitrace_add_causal_test(
     CAUSAL_VALIDATE_ARGS ${_causal_line_110_valid}
     CAUSAL_PASS_REGEX
         "Starting causal experiment #1(.*)causal/experiments.json(.*)causal/experiments.coz"
+    ENVIRONMENT "${_causal_e2e_environment}"
     PROPERTIES PROCESSORS 2 PROCESSOR_AFFINITY OFF)

--- a/tests/source/CMakeLists.txt
+++ b/tests/source/CMakeLists.txt
@@ -1,0 +1,28 @@
+set(CMAKE_BUILD_TYPE "Release")
+find_package(Threads REQUIRED)
+
+add_library(tests-compile-options INTERFACE)
+target_compile_options(tests-compile-options INTERFACE -g)
+
+add_executable(thread-limit thread-limit.cpp)
+target_compile_definitions(thread-limit PRIVATE MAX_THREADS=${OMNITRACE_MAX_THREADS})
+target_link_libraries(thread-limit PRIVATE Threads::Threads tests-compile-options)
+
+set(_thread_limit_environment
+    "${_base_environment}" "OMNITRACE_USE_PERFETTO=ON" "OMNITRACE_USE_TIMEMORY=ON"
+    "OMNITRACE_COUT_OUTPUT=ON" "OMNITRACE_USE_SAMPLING=ON" "OMNITRACE_SAMPLING_FREQ=250"
+    "OMNITRACE_VERBOSE=2" "OMNITRACE_TIMEMORY_COMPONENTS=wall_clock,peak_rss,page_rss")
+
+math(EXPR EXCESS_THREADS "${OMNITRACE_MAX_THREADS} + 24")
+
+omnitrace_add_test(
+    SKIP_BASELINE
+    NAME thread-limit
+    TARGET thread-limit
+    LABELS "max-threads"
+    REWRITE_ARGS -e -v 2 --label return args
+    RUNTIME_ARGS -e -v 1 --label return args
+    RUN_ARGS 35 2 ${EXCESS_THREADS}
+    REWRITE_TIMEOUT 180
+    RUNTIME_TIMEOUT 360
+    ENVIRONMENT "${_thread_limit_environment}")

--- a/tests/source/CMakeLists.txt
+++ b/tests/source/CMakeLists.txt
@@ -13,16 +13,27 @@ set(_thread_limit_environment
     "OMNITRACE_COUT_OUTPUT=ON" "OMNITRACE_USE_SAMPLING=ON" "OMNITRACE_SAMPLING_FREQ=250"
     "OMNITRACE_VERBOSE=2" "OMNITRACE_TIMEMORY_COMPONENTS=wall_clock,peak_rss,page_rss")
 
-math(EXPR EXCESS_THREADS "${OMNITRACE_MAX_THREADS} + 24")
+math(EXPR THREAD_LIMIT_TEST_VALUE "${OMNITRACE_MAX_THREADS} + 24")
+math(EXPR THREAD_LIMIT_TEST_VALUE_PLUS_ONE "${THREAD_LIMIT_TEST_VALUE} + 1")
+
+set(_thread_limit_pass_regex "\\|${THREAD_LIMIT_TEST_VALUE}>>>")
+set(_thread_limit_fail_regex
+    "\\|${THREAD_LIMIT_TEST_VALUE_PLUS_ONE}>>>|OMNITRACE_ABORT_FAIL_REGEX")
 
 omnitrace_add_test(
     SKIP_BASELINE
     NAME thread-limit
     TARGET thread-limit
     LABELS "max-threads"
-    REWRITE_ARGS -e -v 2 --label return args
-    RUNTIME_ARGS -e -v 1 --label return args
-    RUN_ARGS 35 2 ${EXCESS_THREADS}
+    REWRITE_ARGS -e -v 2 -i 1024 --label return args
+    RUNTIME_ARGS -e -v 1 -i 1024 --label return args
+    RUN_ARGS 35 2 ${THREAD_LIMIT_TEST_VALUE}
     REWRITE_TIMEOUT 180
     RUNTIME_TIMEOUT 360
+    RUNTIME_PASS_REGEX "${_thread_limit_pass_regex}"
+    SAMPLING_PASS_REGEX "${_thread_limit_pass_regex}"
+    REWRITE_RUN_PASS_REGEX "${_thread_limit_pass_regex}"
+    RUNTIME_FAIL_REGEX "${_thread_limit_fail_regex}"
+    SAMPLING_FAIL_REGEX "${_thread_limit_fail_regex}"
+    REWRITE_RUN_FAIL_REGEX "${_thread_limit_fail_regex}"
     ENVIRONMENT "${_thread_limit_environment}")

--- a/tests/source/thread-limit.cpp
+++ b/tests/source/thread-limit.cpp
@@ -1,0 +1,86 @@
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+#include <pthread.h>
+#include <random>
+#include <ratio>
+#include <string>
+#include <thread>
+#include <vector>
+
+long
+fib(long n)
+{
+    return (n < 2) ? n : fib(n - 1) + fib(n - 2);
+}
+
+#if !defined(MAX_THREADS)
+#    define MAX_THREADS 4000
+#endif
+
+auto total_duration = std::chrono::duration<long, std::nano>{};
+
+int
+main(int argc, char** argv)
+{
+    std::string _name = argv[0];
+    auto        _pos  = _name.find_last_of('/');
+    if(_pos != std::string::npos) _name = _name.substr(_pos + 1);
+
+    size_t nthread     = 2 * MAX_THREADS;
+    size_t concurrency = std::thread::hardware_concurrency();
+    long   nfib        = 35;
+
+    if(argc > 1) nfib = atol(argv[1]);
+    if(argc > 2) concurrency = atol(argv[2]);
+    if(argc > 3) nthread = atol(argv[3]);
+
+    printf("\n[%s] Threads: %zu\n[%s] concurrency: %zu\n[%s] fibonacci(%li)\n",
+           _name.c_str(), nthread, _name.c_str(), concurrency, _name.c_str(), nfib);
+
+    auto threads = std::vector<std::thread>{};
+    auto _sync   = [_name, &threads]() {
+        std::this_thread::yield();
+        for(auto& itr : threads)
+            itr.join();
+        threads.clear();
+    };
+
+    threads.reserve(concurrency);
+    for(size_t i = 0; i < nthread; ++i)
+    {
+        if(i > MAX_THREADS - 8)
+        {
+            printf("[%s] launching thread %zu (max: %d)...\n", _name.c_str(), i,
+                   MAX_THREADS);
+            fflush(stdout);
+        }
+
+        threads.emplace_back(
+            [](auto n) {
+                auto t0 = std::chrono::steady_clock::now();
+                n       = fib(n);
+                (void) n;
+                auto        diff   = (std::chrono::steady_clock::now() - t0);
+                static auto _mutex = std::mutex{};
+                _mutex.lock();
+                total_duration += diff;
+                _mutex.unlock();
+            },
+            nfib);
+
+        if(i % concurrency == (concurrency - 1)) _sync();
+    }
+
+    _sync();
+
+    printf("[%s] ... completed with an average of %.3f msec per thread\n", _name.c_str(),
+           std::chrono::duration_cast<std::chrono::milliseconds>(total_duration).count() *
+               (1.0 / nthread));
+
+    return 0;
+}


### PR DESCRIPTION
- support dynamic number of threads created by user application
- thread-local data is allocated in blocks of `OMNITRACE_MAX_THREADS` (defined at compile-time)
  - omnitrace stores a lot of thread-specific data in arrays indexed by an integral value unique to that thread
    - this data persists even after the thread destroys it's `static thread_local` allocations
  - previously, if `OMNITRACE_MAX_THREADS=32` then the user application could only create ~31 additional threads at the absolute max before omnitrace aborted
  - Now, omnitrace will allocate chunks in block-sizes of `OMNITRACE_MAX_THREADS` to support an unlimited number of threads, i.e. once the 32nd additional thread is created, omnitrace will resize all the `thread_data` instances to support 32 more threads (i.e. the size is originally 32 and after the resize, the size is 64)
- closes #220 