### PR TITLE
A few fixes for the document

### DIFF
--- a/source/docs/causal_profiling.md
+++ b/source/docs/causal_profiling.md
@@ -22,6 +22,8 @@ Consider the following C++ code executing `foo` and `bar` concurrently in two di
 where `foo` is 30% faster than `bar` (ideally):
 
 ```cpp
+#include <cstddef>
+#include <thread>
 constexpr size_t FOO_N =  7 * 1000000000UL;
 constexpr size_t BAR_N = 10 * 1000000000UL;
 
@@ -37,7 +39,7 @@ void bar()
 
 int main()
 {
-    auto _threads = { std::thread{ foo },
+    std::thread _threads[] = { std::thread{ foo },
                       std::thread{ bar } };
 
     for(auto& itr : _threads)

--- a/source/docs/critical_trace.md
+++ b/source/docs/critical_trace.md
@@ -13,7 +13,7 @@ The steps for generating a critical trace are:
 
 1. Enable the `OMNITRACE_CRITICAL_TRACE` setting
 2. Configure any other relevant critical-trace settings, as needed
-   - `omnitrace-avail --categories settings::critical-trace`
+   - `omnitrace-avail --categories settings::critical_trace`
 3. Execute application
 4. Locate the JSON files with `call-chain` in their name
 5. Provide these files to the `omnitrace-critical-trace` executable

--- a/source/docs/output.md
+++ b/source/docs/output.md
@@ -314,7 +314,7 @@ settings will be ignored. Visit [ui.perfetto.dev](https://ui.perfetto.dev) and o
 Use `omnitrace-avail --components --filename` to view the base filename for each component. E.g.
 
 ```shell
-$ ./omnitrace-avail wall_clock -C -f
+$ omnitrace-avail wall_clock -C -f
 |---------------------------------|---------------|------------------------|
 |            COMPONENT            |   AVAILABLE   |        FILENAME        |
 |---------------------------------|---------------|------------------------|


### PR DESCRIPTION
1. To build the example code in causal_profiling.md with g++ seems need a bit changes(Maybe we don't want to tie it up to specific compiler, but it is good to post code user can try it right away)
2. Other modifications just typo.