### PR TITLE
Enable running setup-env from non-bash shells

### DIFF
--- a/cmake/Templates/setup-env.sh.in
+++ b/cmake/Templates/setup-env.sh.in
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-BASEDIR=$(dirname ${BASH_SOURCE[0]})
+if [ -z "$BASH_SOURCE" ]; then
+    # If not running bash, try to obtain directory with $0
+    BASEDIR="$( cd "$(dirname "$0")"; pwd -P )"
+else
+    BASEDIR=$(dirname ${BASH_SOURCE[0]})
+fi
 command -v realpath &> /dev/null && BASEDIR=$(realpath ${BASEDIR}/../..) || BASEDIR=$(cd ${BASEDIR}/../.. && pwd)
 
 if [ ! -d "${BASEDIR}" ]; then


### PR DESCRIPTION
This PR enables calling `source setup-env.sh` from non-bash shells (tested on zsh) by falling back to `$0` for detecting the script's path.