### PR TITLE
Add option to skip barrier marker events in traces

### DIFF
--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -624,6 +624,10 @@ configure_settings(bool _init)
                              "HSA API type to collect", "", "roctracer", "rocm",
                              "advanced");
 
+    OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_ROCTRACER_DISCARD_BARRIERS",
+                             "Skip barrier marker events in traces", false,
+                             "roctracer", "rocm", "perfetto", "advanced");
+
     OMNITRACE_CONFIG_SETTING(
         std::string, "OMNITRACE_ROCM_EVENTS",
         "ROCm hardware counters. Use ':device=N' syntax to specify collection on device "

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -625,8 +625,8 @@ configure_settings(bool _init)
                              "advanced");
 
     OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_ROCTRACER_DISCARD_BARRIERS",
-                             "Skip barrier marker events in traces", false,
-                             "roctracer", "rocm", "advanced");
+                             "Skip barrier marker events in traces", false, "roctracer",
+                             "rocm", "advanced");
 
     OMNITRACE_CONFIG_SETTING(
         std::string, "OMNITRACE_ROCM_EVENTS",
@@ -1332,7 +1332,8 @@ get_use_sampling_cputime()
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
-std::set<int> get_sampling_signals(int64_t)
+std::set<int>
+get_sampling_signals(int64_t)
 {
     auto _v = std::set<int>{};
     if(get_use_causal())

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -1332,8 +1332,7 @@ get_use_sampling_cputime()
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
-std::set<int>
-get_sampling_signals(int64_t)
+std::set<int> get_sampling_signals(int64_t)
 {
     auto _v = std::set<int>{};
     if(get_use_causal())

--- a/source/lib/core/config.cpp
+++ b/source/lib/core/config.cpp
@@ -626,7 +626,7 @@ configure_settings(bool _init)
 
     OMNITRACE_CONFIG_SETTING(bool, "OMNITRACE_ROCTRACER_DISCARD_BARRIERS",
                              "Skip barrier marker events in traces", false,
-                             "roctracer", "rocm", "perfetto", "advanced");
+                             "roctracer", "rocm", "advanced");
 
     OMNITRACE_CONFIG_SETTING(
         std::string, "OMNITRACE_ROCM_EVENTS",

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -868,11 +868,10 @@ hip_activity_callback(const char* begin, const char* end, void* arg)
     using Phase  = critical_trace::Phase;
 
     if(!trait::runtime_enabled<comp::roctracer>::get()) return;
-    static auto _kernel_names        = std::unordered_map<const char*, std::string>{};
-    static auto _indexes             = std::unordered_map<uint64_t, int>{};
+    static auto _kernel_names = std::unordered_map<const char*, std::string>{};
+    static auto _indexes      = std::unordered_map<uint64_t, int>{};
     static auto _skip_barrier_packets =
-        config::get_setting_value<bool>(
-            "OMNITRACE_ROCTRACER_DISCARD_BARRIERS")
+        config::get_setting_value<bool>("OMNITRACE_ROCTRACER_DISCARD_BARRIERS")
             .value_or(false);
     const roctracer_record_t* record = reinterpret_cast<const roctracer_record_t*>(begin);
     const roctracer_record_t* end_record =

--- a/source/lib/omnitrace/library/roctracer.cpp
+++ b/source/lib/omnitrace/library/roctracer.cpp
@@ -900,7 +900,7 @@ hip_activity_callback(const char* begin, const char* end, void* arg)
         }
         if(record->domain != ACTIVITY_DOMAIN_HIP_OPS) continue;
         if(record->op > HIP_OP_ID_BARRIER) continue;
-        if (_skip_barrier_packets && record->op == HIP_OP_ID_BARRIER) continue;
+        if(_skip_barrier_packets && record->op == HIP_OP_ID_BARRIER) continue;
 
         const char* op_name =
             roctracer_op_string(record->domain, record->op, record->kind);


### PR DESCRIPTION
When inspecting traces with multiple queues, barrier events can be overwhelming on the profile. This PR creates a config entry to not include those in the output file. The configuration is disabled by default, so it should not affect the existing behavior.