### PR TITLE
Fix MPI test failures

### DIFF
--- a/tests/omnitrace-mpi-tests.cmake
+++ b/tests/omnitrace-mpi-tests.cmake
@@ -13,7 +13,7 @@ omnitrace_add_test(
     NAME "mpi"
     TARGET mpi-example
     MPI ON
-    NUM_PROCS 4
+    NUM_PROCS 2
     REWRITE_ARGS
         -e
         -v
@@ -37,7 +37,7 @@ omnitrace_add_test(
     NAME "mpi-flat-mpip"
     TARGET mpi-example
     MPI ON
-    NUM_PROCS 4
+    NUM_PROCS 2
     LABELS "mpip"
     REWRITE_ARGS
         -e
@@ -60,7 +60,7 @@ omnitrace_add_test(
     NAME "mpi-flat"
     TARGET mpi-example
     MPI ON
-    NUM_PROCS 4
+    NUM_PROCS 2
     LABELS "mpip"
     REWRITE_ARGS
         -e


### PR DESCRIPTION
The CI test machines only have 2 MPI slots. MPI tests were failing when requesting 4 slots. Update these tests to request 2 slots.

Tested on CI docker image with MPI configured to have 2 slots.