### PR TITLE
Fix thread-limit bug in roctracer

### DIFF
--- a/source/lib/omnitrace/library/components/roctracer.cpp
+++ b/source/lib/omnitrace/library/components/roctracer.cpp
@@ -306,6 +306,8 @@ roctracer::flush()
     // make sure all async operations are executed
     for(size_t i = 0; i < thread_info::get_peak_num_threads(); ++i)
         hip_exec_activity_callbacks(i);
+
+    OMNITRACE_VERBOSE_F(2, "roctracer flush completed\n");
 }
 
 void


### PR DESCRIPTION
- fix call to `hip_exec_activity_callbacks` when more runtime threads than compile time max threads