### PR TITLE
comment out verify_instrumented_preloaded as fix for SWDEV-486345 

### DIFF
--- a/source/lib/omnitrace-dl/dl.cpp
+++ b/source/lib/omnitrace-dl/dl.cpp
@@ -1264,7 +1264,7 @@ omnitrace_preload()
         }
     }
 
-    verify_instrumented_preloaded();
+    //verify_instrumented_preloaded();
 
     static bool _once = false;
     if(_once) return _preload;


### PR DESCRIPTION
The preload verification interferes when loading linked instrumented libraries.