### PR TITLE
Update documentation requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core[api_reference]==1.4.1
+rocm-docs-core[api_reference]==1.8.2

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -6,9 +6,9 @@
 #
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
-babel==2.15.0
+babel==2.16.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
@@ -16,9 +16,9 @@ beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 breathe==4.35.0
     # via rocm-docs-core
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
@@ -41,7 +41,7 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
-doxysphinx==3.3.9
+doxysphinx==3.3.10
     # via rocm-docs-core
 fastjsonschema==2.20.0
     # via rocm-docs-core
@@ -49,7 +49,7 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via rocm-docs-core
-idna==3.7
+idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -67,13 +67,13 @@ markdown-it-py==3.0.0
     #   myst-parser
 markupsafe==2.1.5
     # via jinja2
-mdit-py-plugins==0.4.1
+mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
 mpire==2.10.2
     # via doxysphinx
-myst-parser==3.0.1
+myst-parser==4.0.0
     # via rocm-docs-core
 numpy==1.26.4
     # via doxysphinx
@@ -87,7 +87,7 @@ pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
-pygithub==2.3.0
+pygithub==2.4.0
     # via rocm-docs-core
 pygments==2.18.0
     # via
@@ -97,13 +97,13 @@ pygments==2.18.0
     #   sphinx
 pyjson5==1.6.6
     # via doxysphinx
-pyjwt[crypto]==2.8.0
+pyjwt[crypto]==2.9.0
     # via pygithub
 pynacl==1.5.0
     # via pygithub
-pyparsing==3.1.2
+pyparsing==3.1.4
     # via doxysphinx
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   myst-parser
     #   rocm-docs-core
@@ -112,15 +112,15 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api-reference]==1.4.1
+rocm-docs-core[api-reference]==1.8.2
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
-sphinx==7.3.7
+sphinx==8.0.2
     # via
     #   breathe
     #   myst-parser
@@ -135,33 +135,33 @@ sphinx-book-theme==1.1.3
     # via rocm-docs-core
 sphinx-copybutton==0.5.2
     # via rocm-docs-core
-sphinx-design==0.6.0
+sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
     # via rocm-docs-core
-sphinx-notfound-page==1.0.2
+sphinx-notfound-page==1.0.4
     # via rocm-docs-core
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tomli==2.0.1
+tomli==2.0.2
     # via sphinx
-tqdm==4.66.4
+tqdm==4.66.5
     # via mpire
 typing-extensions==4.12.2
     # via
     #   pydata-sphinx-theme
     #   pygithub
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   pygithub
     #   requests


### PR DESCRIPTION
[Bump rocm-docs-core to 1.8.2](https://github.com/ROCm/omnitrace/commit/2c60486aac78c4bfbd424cb3c8c8bd279d765024)
Includes updates for rocm-docs-core to keep header version number current for the "latest" version of the doc build

[Remove empty package-ecosystem in dependabot](https://github.com/ROCm/omnitrace/commit/0b1918e0e87269bcad8526f17fc1ea8317c5b898)
package-ecosystem needs a value. this seems to have been stopping dependabot PRs to auto update rocm-docs-core