### PR TITLE
Handle get_omnitrace_is_preloaded() function called multiple times

### DIFF
--- a/source/lib/omnitrace-dl/dl.cpp
+++ b/source/lib/omnitrace-dl/dl.cpp
@@ -108,12 +108,19 @@ get_omnitrace_dl_env()
                : get_env("OMNITRACE_DL_VERBOSE", get_omnitrace_env());
 }
 
-inline bool&
+inline bool
 get_omnitrace_is_preloaded()
 {
+    auto preloaded_env = get_env("OMNITRACE_DL_IS_PRELOADED", std::string{});
+    if(preloaded_env == "true")
+        return true;
+
     static bool _v = []() {
         auto&& _preload_libs = get_env("LD_PRELOAD", std::string{});
-        return (_preload_libs.find("libomnitrace-dl.so") != std::string::npos);
+        auto&& preloaded_f = _preload_libs.find("libomnitrace-dl.so") != std::string::npos;
+        if(preloaded_f)
+            setenv("OMNITRACE_DL_IS_PRELOADED", "true", 1);
+        return (preloaded_f);
     }();
     return _v;
 }

--- a/source/lib/omnitrace-dl/dl.cpp
+++ b/source/lib/omnitrace-dl/dl.cpp
@@ -112,14 +112,13 @@ inline bool
 get_omnitrace_is_preloaded()
 {
     auto preloaded_env = get_env("OMNITRACE_DL_IS_PRELOADED", std::string{});
-    if(preloaded_env == "true")
-        return true;
+    if(preloaded_env == "true") return true;
 
     static bool _v = []() {
         auto&& _preload_libs = get_env("LD_PRELOAD", std::string{});
-        auto&& preloaded_f = _preload_libs.find("libomnitrace-dl.so") != std::string::npos;
-        if(preloaded_f)
-            setenv("OMNITRACE_DL_IS_PRELOADED", "true", 1);
+        auto&& preloaded_f =
+            _preload_libs.find("libomnitrace-dl.so") != std::string::npos;
+        if(preloaded_f) setenv("OMNITRACE_DL_IS_PRELOADED", "true", 1);
         return (preloaded_f);
     }();
     return _v;


### PR DESCRIPTION
get_omnitrace_is_preloaded() is called multiple times likely before the LD_PRELOAD environment variable is set to false in the code. The updated function sets a new environment variable once it finds that libomnitrace-dl.so has been loaded.  Subsequent calls do not check for that libomnitrace-dl.so has been loaded after seeing that the OMNITRACE_DL_IS_PRELOADED environment variable is set to true. I have tested this code, and it runs fine, generating the trace results.