### PR TITLE
Escape the arguments to be executed via eval

### DIFF
--- a/cmake/Templates/console-script.in
+++ b/cmake/Templates/console-script.in
@@ -14,4 +14,4 @@ run-script()
     eval $@
 }
 
-run-script ${PYTHON_EXECUTABLE} -m @SCRIPT_SUBMODULE@ $@
+run-script ${PYTHON_EXECUTABLE} -m @SCRIPT_SUBMODULE@ "$(printf ' %q' "$@")"


### PR DESCRIPTION
Refer to https://stackoverflow.com/a/50367671

As eval builtin interprets its arguments in the same way as shell would do, which would need some escape work, otherwise, it won't work if the input arguments contains e.g. a JSON string:

omnitrace-python -- ./test.py --json='{"foo": "bar"}'