### PR TITLE
Update workflow to install cmake-3.18.4

### DIFF
--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -62,7 +62,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Configure Env

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -62,7 +62,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Configure Env

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -76,7 +76,7 @@ jobs:
           yum install -y curl dpkg-devel numactl-devel openmpi-devel papi-devel python3-pip texinfo wget which zlib-devel &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages

--- a/.github/workflows/redhat.yml
+++ b/.github/workflows/redhat.yml
@@ -76,7 +76,7 @@ jobs:
           yum install -y curl dpkg-devel numactl-devel openmpi-devel papi-devel python3-pip texinfo wget which zlib-devel &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -98,7 +98,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done &&
           apt-get -y --purge autoremove &&
           apt-get -y clean &&
@@ -280,7 +280,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done &&
           apt-get -y --purge autoremove &&
           apt-get -y clean &&
@@ -443,7 +443,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           sudo apt-get -y --purge autoremove &&
           sudo apt-get -y clean
 
@@ -596,7 +596,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           for i in 6 7 8 9 10; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done &&
           apt-get -y --purge autoremove &&
           apt-get -y clean &&

--- a/.github/workflows/ubuntu-focal.yml
+++ b/.github/workflows/ubuntu-focal.yml
@@ -98,7 +98,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done &&
           apt-get -y --purge autoremove &&
           apt-get -y clean &&
@@ -280,7 +280,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done &&
           apt-get -y --purge autoremove &&
           apt-get -y clean &&
@@ -443,7 +443,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           sudo apt-get -y --purge autoremove &&
           sudo apt-get -y clean
 
@@ -596,7 +596,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           for i in 6 7 8 9 10; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done &&
           apt-get -y --purge autoremove &&
           apt-get -y clean &&

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -114,7 +114,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install --upgrade cmake &&
+          python3 -m pip install 'cmake==3.21' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages

--- a/.github/workflows/ubuntu-jammy.yml
+++ b/.github/workflows/ubuntu-jammy.yml
@@ -114,7 +114,7 @@ jobs:
           chmod +x /opt/trace_processor/bin/trace_processor_shell &&
           python3 -m pip install --upgrade pip &&
           python3 -m pip install --upgrade numpy perfetto dataclasses &&
-          python3 -m pip install 'cmake==3.21' &&
+          python3 -m pip install 'cmake==3.18.4' &&
           for i in 6 7 8 9 10 11; do /opt/conda/envs/py3.${i}/bin/python -m pip install --upgrade numpy perfetto dataclasses; done
 
     - name: Install ROCm Packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND CMAKE_CURRENT_SOURCE_DIR STREQUAL
                                                   CMAKE_SOURCE_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR AND CMAKE_CURRENT_SOURCE_DIR STREQUAL
                                                   CMAKE_SOURCE_DIR)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-examples LANGUAGES C CXX)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-examples LANGUAGES C CXX)
 

--- a/examples/causal/CMakeLists.txt
+++ b/examples/causal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-causal-example LANGUAGES CXX)
 

--- a/examples/causal/CMakeLists.txt
+++ b/examples/causal/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-causal-example LANGUAGES CXX)
 

--- a/examples/code-coverage/CMakeLists.txt
+++ b/examples/code-coverage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-code-coverage-example LANGUAGES CXX)
 

--- a/examples/code-coverage/CMakeLists.txt
+++ b/examples/code-coverage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-code-coverage-example LANGUAGES CXX)
 

--- a/examples/fork/CMakeLists.txt
+++ b/examples/fork/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-fork LANGUAGES CXX)
 

--- a/examples/fork/CMakeLists.txt
+++ b/examples/fork/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-fork LANGUAGES CXX)
 

--- a/examples/lulesh/CMakeLists.txt
+++ b/examples/lulesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-lulesh-example LANGUAGES C CXX)
 

--- a/examples/lulesh/CMakeLists.txt
+++ b/examples/lulesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-lulesh-example LANGUAGES C CXX)
 

--- a/examples/mpi/CMakeLists.txt
+++ b/examples/mpi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-mpi-examples LANGUAGES C CXX)
 

--- a/examples/mpi/CMakeLists.txt
+++ b/examples/mpi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-mpi-examples LANGUAGES C CXX)
 

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-openmp LANGUAGES CXX)
 

--- a/examples/openmp/CMakeLists.txt
+++ b/examples/openmp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-openmp LANGUAGES CXX)
 

--- a/examples/openmp/target/CMakeLists.txt
+++ b/examples/openmp/target/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 #
 #
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 # try to find a compatible HIP version
 if(ROCmVersion_MAJOR_VERSION AND ROCmVersion_MAJOR_VERSION GREATER_EQUAL 6)

--- a/examples/openmp/target/CMakeLists.txt
+++ b/examples/openmp/target/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 #
 #
-cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 # try to find a compatible HIP version
 if(ROCmVersion_MAJOR_VERSION AND ROCmVersion_MAJOR_VERSION GREATER_EQUAL 6)

--- a/examples/parallel-overhead/CMakeLists.txt
+++ b/examples/parallel-overhead/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-parallel-overhead-example LANGUAGES CXX)
 

--- a/examples/parallel-overhead/CMakeLists.txt
+++ b/examples/parallel-overhead/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-parallel-overhead-example LANGUAGES CXX)
 

--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-python)
 

--- a/examples/python/CMakeLists.txt
+++ b/examples/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-python)
 

--- a/examples/rccl/CMakeLists.txt
+++ b/examples/rccl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-rccl-example LANGUAGES CXX)
 

--- a/examples/rccl/CMakeLists.txt
+++ b/examples/rccl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-rccl-example LANGUAGES CXX)
 

--- a/examples/rewrite-caller/CMakeLists.txt
+++ b/examples/rewrite-caller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-rewrite-caller-example LANGUAGES CXX)
 

--- a/examples/rewrite-caller/CMakeLists.txt
+++ b/examples/rewrite-caller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-rewrite-caller-example LANGUAGES CXX)
 

--- a/examples/trace-time-window/CMakeLists.txt
+++ b/examples/trace-time-window/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-trace-time-window-example LANGUAGES CXX)
 

--- a/examples/trace-time-window/CMakeLists.txt
+++ b/examples/trace-time-window/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-trace-time-window-example LANGUAGES CXX)
 

--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-transpose-example LANGUAGES CXX)
 

--- a/examples/transpose/CMakeLists.txt
+++ b/examples/transpose/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-transpose-example LANGUAGES CXX)
 

--- a/examples/user-api/CMakeLists.txt
+++ b/examples/user-api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(omnitrace-user-api-example LANGUAGES CXX)
 

--- a/examples/user-api/CMakeLists.txt
+++ b/examples/user-api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(omnitrace-user-api-example LANGUAGES CXX)
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -207,7 +207,7 @@ EOF
 verbose-run cd ${BINARY_DIR}
 
 cat << EOF > dashboard.cmake
-cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 include("\${CMAKE_CURRENT_LIST_DIR}/CTestCustom.cmake")
 

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -207,7 +207,7 @@ EOF
 verbose-run cd ${BINARY_DIR}
 
 cat << EOF > dashboard.cmake
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 include("\${CMAKE_CURRENT_LIST_DIR}/CTestCustom.cmake")
 

--- a/scripts/test-find-package.sh
+++ b/scripts/test-find-package.sh
@@ -112,7 +112,7 @@ verbose-run cp -v -r ${EXAMPLE_DIR}/${EXAMPLE_NAME}/* ${SOURCE_DIR}/
 verbose-run pushd ${SOURCE_DIR}
 
 cat << EOF > CMakeLists.txt
-cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.4 FATAL_ERROR)
 
 project(test LANGUAGES C CXX)
 

--- a/scripts/test-find-package.sh
+++ b/scripts/test-find-package.sh
@@ -112,7 +112,7 @@ verbose-run cp -v -r ${EXAMPLE_DIR}/${EXAMPLE_NAME}/* ${SOURCE_DIR}/
 verbose-run pushd ${SOURCE_DIR}
 
 cat << EOF > CMakeLists.txt
-cmake_minimum_required(VERSION 3.16.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
 project(test LANGUAGES C CXX)
 

--- a/scripts/write-omnitrace-install.cmake
+++ b/scripts/write-omnitrace-install.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.18.4)
 
 if(NOT DEFINED OMNITRACE_VERSION)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/../VERSION" FULL_VERSION_STRING LIMIT_COUNT 1)


### PR DESCRIPTION
Update internal CMake files to match with `cmake_minimum_requred(VERSION 3.18.4)`
This was the latest version used all the project's `cmake_minimum_required` definitions.