### PR TITLE
Update README with rebranding message

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 [![Documentation](https://github.com/ROCm/omnitrace/actions/workflows/docs.yml/badge.svg)](https://github.com/ROCm/omnitrace/actions/workflows/docs.yml)
 
 > [!NOTE]
-> Perfetto validation is done with trace_processor v46.0, as there is a known issue with v47.0.
-If you are experiencing problems viewing your trace in the latest version of [Perfetto](http://ui.perfetto.dev), then try using [Perfetto UI v46.0](https://ui.perfetto.dev/v46.0-35b3d9845/#!/).
+> Omnitrace is being rebranded to ROCm Systems Profiler and its new home is <https://github.com/ROCm/rocprofiler-systems>.
+All future development will occur in the new repository; this includes upgrading the tool to use [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk).
+This repository will remain open for some time and can be used with versions of ROCm before the introduction of rocprofiler-sdk (ie., pre ROCm-6.2).
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > [!NOTE]
 > Omnitrace is being rebranded to ROCm Systems Profiler and its new home is <https://github.com/ROCm/rocprofiler-systems>.
 All future development will occur in the new repository; this includes upgrading the tool to use [rocprofiler-sdk](https://github.com/ROCm/rocprofiler-sdk).
-This repository will remain open for some time and can be used with versions of ROCm before the introduction of rocprofiler-sdk (ie., pre ROCm-6.2).
+This repository will remain open for some time and can be used with versions of ROCm before the introduction of rocprofiler-sdk (that is, before ROCm version 6.2).
 
 ## Overview
 

--- a/docs/how-to/understanding-omnitrace-output.rst
+++ b/docs/how-to/understanding-omnitrace-output.rst
@@ -323,11 +323,6 @@ absolute path, then all ``OMNITRACE_OUTPUT_PATH`` and similar
 settings are ignored. Visit `ui.perfetto.dev <https://ui.perfetto.dev>`_ and open
 this file.
 
-.. important::
-   Perfetto validation is done with trace_processor v46.0 as there is a known issue with v47.0.
-   If you are experiencing problems viewing your trace in the latest version of `Perfetto <http://ui.perfetto.dev>`_,
-   then try using `Perfetto UI v46.0 <https://ui.perfetto.dev/v46.0-35b3d9845/#!/>`_.
-
 .. image:: ../data/omnitrace-perfetto.png
    :alt: Visualization of a performance graph in Perfetto
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -250,11 +250,6 @@ into Perfetto support for Omnitrace, for example, ``OMNITRACE_USE_PAPI=<VAL>`` a
 is passed along to Perfetto and is displayed when the ``.proto`` file is visualized
 in `the Perfetto UI <https://ui.perfetto.dev>`_.
 
-.. important::
-   Perfetto validation is done with trace_processor v46.0 as there is a known issue with v47.0.
-   If you are experiencing problems viewing your trace in the latest version of `Perfetto <http://ui.perfetto.dev>`_,
-   then try using `Perfetto UI v46.0 <https://ui.perfetto.dev/v46.0-35b3d9845/#!/>`_.
-
 .. code-block:: shell
 
    git clone https://github.com/ROCm/omnitrace.git omnitrace-source

--- a/docs/what-is-omnitrace.rst
+++ b/docs/what-is-omnitrace.rst
@@ -15,11 +15,6 @@ A visualization of the comprehensive Omnitrace results can be observed in any mo
 web browser. Upload the Perfetto (``.proto``) output files produced by Omnitrace at
 `ui.perfetto.dev <https://ui.perfetto.dev/>`_ to see the details.
 
-.. important::
-   Perfetto validation is done with trace_processor v46.0 as there is a known issue with v47.0.
-   If you are experiencing problems viewing your trace in the latest version of `Perfetto <http://ui.perfetto.dev>`_,
-   then try using `Perfetto UI v46.0 <https://ui.perfetto.dev/v46.0-35b3d9845/#!/>`_.
-
 Aggregated high-level results are available as human-readable text files and
 JSON files for programmatic analysis. The JSON output files are compatible with the
 `hatchet <https://github.com/hatchet/hatchet>`_ Python package. Hatchet converts


### PR DESCRIPTION
Also, remove notes about Perfetto workaround. This was fixed in:
<https://github.com/ROCm/omnitrace/pull/411>