### PR TITLE
Added extra command line option to turn off rccl for causal tests

### DIFF
--- a/source/bin/omnitrace-causal/impl.cpp
+++ b/source/bin/omnitrace-causal/impl.cpp
@@ -607,6 +607,11 @@ parse_args(int argc, char** argv, std::vector<char*>& _env,
         .action([&](parser_t& p) {
             update_env(_env, "OMNITRACE_CAUSAL_DURATION", p.get<double>("duration"));
         });
+    
+    parser
+        .add_argument({ "--nrccl" },
+                      "Don't set Use_RCCLP environment variable to true.")
+        .max_count(1);
 
     int64_t _niterations       = 1;
     auto    _virtual_speedups  = std::vector<std::string>{};
@@ -828,7 +833,17 @@ parse_args(int argc, char** argv, std::vector<char*>& _env,
 #endif
 
 #if defined(OMNITRACE_USE_RCCL) && OMNITRACE_USE_RCCL > 0
-        add_default_env(_env, "OMNITRACE_USE_RCCLP", true);
+        bool add_to_env = true;
+        for(int i = 0; i < argc; ++i)
+        {
+            if(std::string_view{ argv[i] } == "--nrccl")
+            {
+                add_to_env = false;
+            }
+        }
+        if (add_to_env){
+            add_default_env(_env, "OMNITRACE_USE_RCCLP", true);
+        }
 #endif
     }
 

--- a/tests/omnitrace-testing.cmake
+++ b/tests/omnitrace-testing.cmake
@@ -637,7 +637,7 @@ function(OMNITRACE_ADD_CAUSAL_TEST)
 
     if(TARGET ${TEST_TARGET})
         set(COMMAND_PREFIX $<TARGET_FILE:omnitrace-causal> --reset -m ${TEST_CAUSAL_MODE}
-                           ${TEST_CAUSAL_ARGS} --)
+                   ${TEST_CAUSAL_ARGS} --nrccl --)
 
         if(NOT TEST_SKIP_BASELINE)
             add_test(


### PR DESCRIPTION
USE_RCCL is ON by default from the CMakeLists.txt whenever USE_HIP is ON so omnitrace-causal always has this setting turn on from the compile stage.  I added an extra option so the environment variable will not be selectively added to the run environment when an extra command line argument --nrccl is passed. This extra command line argument is used by the add_causal_test to run omnitrace-causal without USE_RCCLP set to true.